### PR TITLE
Fix process hanging and hide stale init tip

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,6 +63,7 @@ program
       // First-run detection: check for config file, not just directory
       const paths = getAppPaths();
       if (
+        listProviders().length === 0 &&
         !existsSync(join(paths.config, "config.toml")) &&
         !opts.json &&
         !opts.quiet
@@ -130,7 +131,9 @@ registerScheduleCommand(program);
 registerPluginCommand(program);
 
 // Parse and run
-program.parseAsync(process.argv).catch((err) => {
+program.parseAsync(process.argv).then(() => {
+  process.exit(0);
+}).catch((err) => {
   const msg = err instanceof Error ? err.message : String(err);
   console.error("Fatal:", msg.length > 500 ? msg.slice(0, 500) + "..." : msg);
   process.exit(ExitCode.Error);


### PR DESCRIPTION
## Summary
- **Process exit**: Added `process.exit(0)` after `parseAsync()` resolves, so lingering puppeteer-core/inquirer handles no longer keep Bun's event loop alive. Commands like `providers add`, `providers list` (with auto-fetch), and `accounts` now exit cleanly without needing Ctrl+C.
- **Init tip**: Added `listProviders().length === 0` check so the "Run kolshek init" tip only shows when there are truly no providers in the DB — not just when `config.toml` is missing.

## Test plan
- [ ] Run `kolshek accounts` with existing providers — should exit immediately, no tip shown
- [ ] Run `kolshek providers list` — should exit immediately after printing
- [ ] Run `kolshek providers add` through the full flow — should exit after completion
- [ ] Run with no providers and no config.toml — tip should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)