### PR TITLE
Show provider alias in all CLI output

### DIFF
--- a/src/cli/commands/accounts.ts
+++ b/src/cli/commands/accounts.ts
@@ -24,6 +24,7 @@ interface AccountWithProviderRow {
   created_at: string;
   provider_display_name: string;
   provider_company_id: string;
+  provider_alias: string;
   provider_type: string;
   last_synced_at: string | null;
 }
@@ -41,6 +42,7 @@ function listAccountsWithProviders(): AccountWithProviderRow[] {
         a.created_at,
         p.display_name AS provider_display_name,
         p.company_id AS provider_company_id,
+        p.alias AS provider_alias,
         p.type AS provider_type,
         p.last_synced_at
       FROM accounts a
@@ -79,6 +81,7 @@ export function registerAccountsCommand(program: Command): void {
               balance: a.balance,
               currency: a.currency,
               provider: a.provider_company_id,
+              providerAlias: a.provider_alias,
               providerName: a.provider_display_name,
               providerType: a.provider_type,
               lastSyncedAt: a.last_synced_at,
@@ -102,7 +105,7 @@ export function registerAccountsCommand(program: Command): void {
       const table = createTable(
         ["Provider", "Account", "Balance", "Currency", "Last Synced"],
         accounts.map((a) => [
-          a.provider_display_name,
+          a.provider_alias,
           formatAccountNumber(a.account_number, true),
           a.balance != null
             ? formatCurrency(a.balance, a.currency)

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -156,7 +156,7 @@ export async function runFetch(opts: FetchOptions = {}): Promise<void> {
       ? `${r.scrapeStartDate} → ${r.scrapeEndDate}`
       : "";
     return [
-      r.companyId,
+      r.alias,
       r.success ? "✓" : "✗",
       range,
       String(r.transactionsAdded),

--- a/src/cli/commands/reports.ts
+++ b/src/cli/commands/reports.ts
@@ -210,7 +210,7 @@ export function registerReportsCommand(program: Command): void {
           "30d Income",
         ],
         accounts.map((a) => [
-          a.provider,
+          a.providerAlias,
           a.providerType,
           a.accountNumber,
           a.balance != null ? formatCurrency(a.balance, a.currency) : "N/A",

--- a/src/cli/commands/transactions.ts
+++ b/src/cli/commands/transactions.ts
@@ -42,7 +42,7 @@ function txRow(tx: TransactionWithContext, masked: boolean): string[] {
     desc.length > 40 ? desc.slice(0, 37) + "..." : desc,
     formatCurrency(tx.chargedAmount, tx.chargedCurrency ?? "ILS"),
     tx.status === "pending" ? "pending" : "",
-    tx.providerDisplayName,
+    tx.providerAlias,
     formatAccountNumber(tx.accountNumber, masked),
   ];
 }
@@ -67,6 +67,7 @@ function txToJson(tx: TransactionWithContext): Record<string, unknown> {
     installmentNumber: tx.installmentNumber,
     installmentTotal: tx.installmentTotal,
     provider: tx.providerCompanyId,
+    providerAlias: tx.providerAlias,
     providerName: tx.providerDisplayName,
     accountNumber: tx.accountNumber,
   };
@@ -231,6 +232,7 @@ export function registerTransactionsCommand(program: Command): void {
           "installment_number",
           "installment_total",
           "provider",
+          "provider_alias",
           "account_number",
         ];
         const rows = txns.map((tx) =>
@@ -251,6 +253,7 @@ export function registerTransactionsCommand(program: Command): void {
             tx.installmentNumber != null ? String(tx.installmentNumber) : "",
             tx.installmentTotal != null ? String(tx.installmentTotal) : "",
             csvEscape(tx.providerCompanyId),
+            csvEscape(tx.providerAlias),
             csvEscape(tx.accountNumber),
           ].join(","),
         );

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -142,6 +142,7 @@ export async function syncProviders(
     return {
       results: targets.map((p) => ({
         companyId: p.companyId,
+        alias: p.alias,
         success: false,
         accountsFound: 0,
         transactionsAdded: 0,
@@ -199,6 +200,7 @@ async function syncSingleProvider(
   if (!isValidCompanyId(companyId)) {
     return {
       companyId,
+      alias,
       success: false,
       accountsFound: 0,
       transactionsAdded: 0,
@@ -215,6 +217,7 @@ async function syncSingleProvider(
   if (!credentials) {
     return {
       companyId,
+      alias,
       success: false,
       accountsFound: 0,
       transactionsAdded: 0,
@@ -264,6 +267,7 @@ async function syncSingleProvider(
       completeSyncLog(syncLog.id, "error", 0, 0, errMsg);
       return {
         companyId,
+        alias,
         success: false,
         accountsFound: 0,
         transactionsAdded: 0,
@@ -283,6 +287,7 @@ async function syncSingleProvider(
       completeSyncLog(syncLog.id, "error", 0, 0, safeError);
       return {
         companyId,
+        alias,
         success: false,
         accountsFound: scrapeResult.accounts.length,
         transactionsAdded: 0,
@@ -365,6 +370,7 @@ async function syncSingleProvider(
 
     return {
       companyId,
+      alias,
       success: true,
       accountsFound: scrapeResult.accounts.length,
       transactionsAdded: totalAdded,

--- a/src/db/repositories/reports.ts
+++ b/src/db/repositories/reports.ts
@@ -201,6 +201,7 @@ export function getMerchantReport(
 
 export interface BalanceRow {
   provider: string;
+  providerAlias: string;
   providerType: string;
   accountNumber: string;
   balance: number | null;
@@ -216,6 +217,7 @@ export function getBalanceReport(): BalanceRow[] {
   const sql = `
     SELECT
       p.display_name AS provider,
+      p.alias AS provider_alias,
       p.type AS provider_type,
       a.account_number,
       a.balance,
@@ -244,6 +246,7 @@ export function getBalanceReport(): BalanceRow[] {
 
   const rows = db.prepare(sql).all() as Array<{
     provider: string;
+    provider_alias: string;
     provider_type: string;
     account_number: string;
     balance: number | null;
@@ -255,6 +258,7 @@ export function getBalanceReport(): BalanceRow[] {
 
   return rows.map((r) => ({
     provider: r.provider,
+    providerAlias: r.provider_alias,
     providerType: r.provider_type,
     accountNumber: r.account_number,
     balance: r.balance,

--- a/src/db/repositories/transactions.ts
+++ b/src/db/repositories/transactions.ts
@@ -34,6 +34,7 @@ interface TransactionWithContextRow {
   updated_at: string;
   provider_display_name: string;
   provider_company_id: string;
+  provider_alias: string;
   account_number: string;
 }
 
@@ -64,6 +65,7 @@ function rowToTransactionWithContext(
     updatedAt: row.updated_at,
     providerDisplayName: row.provider_display_name,
     providerCompanyId: row.provider_company_id,
+    providerAlias: row.provider_alias,
     accountNumber: row.account_number,
   };
 }
@@ -224,6 +226,7 @@ function buildContextQuery(
       t.*,
       p.display_name AS provider_display_name,
       p.company_id AS provider_company_id,
+      p.alias AS provider_alias,
       a.account_number
     FROM transactions t
     JOIN accounts a ON t.account_id = a.id

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 /** Sync result for a single provider */
 export interface ProviderSyncResult {
   companyId: string;
+  alias: string;
   success: boolean;
   accountsFound: number;
   transactionsAdded: number;

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -56,6 +56,7 @@ export interface TransactionInput {
 export interface TransactionWithContext extends Transaction {
   providerDisplayName: string;
   providerCompanyId: string;
+  providerAlias: string;
   accountNumber: string;
 }
 


### PR DESCRIPTION
## Summary
- Use provider alias instead of display name/company ID in all CLI output (accounts, transactions, fetch, reports)
- Prevents confusion when multiple instances of the same provider exist (e.g., two "Bank Leumi" accounts now show as "leumi-personal" vs "leumi-joint")
- Added `providerAlias` to JSON output and CSV export for programmatic consumers

## Test plan
- [ ] `kolshek accounts` — Provider column shows alias
- [ ] `kolshek tx list --limit 5` — Provider column shows alias
- [ ] `kolshek tx list --json --limit 5` — `providerAlias` field present
- [ ] `kolshek tx export csv --output test.csv` — `provider_alias` column present
- [ ] `kolshek fetch` — Provider column shows alias instead of companyId
- [ ] `kolshek reports balance` — Provider column shows alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)