### PR TITLE
Handle CC billing charges to prevent double-counting

### DIFF
--- a/plugin/integrations/antigravity/kolshek-categorize/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-categorize/SKILL.md
@@ -40,6 +40,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/plugin/integrations/cursor/rules/kolshek-categorize.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-categorize.mdc
@@ -38,6 +38,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/plugin/integrations/gemini-cli/skills/kolshek-categorize/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-categorize/SKILL.md
@@ -37,6 +37,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/plugin/integrations/openclaw/kolshek-categorize/SKILL.md
+++ b/plugin/integrations/openclaw/kolshek-categorize/SKILL.md
@@ -40,6 +40,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND category IS NULL GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/plugin/integrations/opencode/agent/kolshek-categorize.md
+++ b/plugin/integrations/opencode/agent/kolshek-categorize.md
@@ -38,6 +38,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/plugin/skills/categorize/SKILL.md
+++ b/plugin/skills/categorize/SKILL.md
@@ -39,6 +39,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
 
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+
 ## Step 3: Suggest Categories
 
 Generate category suggestions for both expenses and income. Present as two tables:

--- a/src/cli/commands/reports.ts
+++ b/src/cli/commands/reports.ts
@@ -71,10 +71,12 @@ export function registerReportsCommand(program: Command): void {
       const totals = months.reduce(
         (acc, m) => ({
           income: acc.income + m.income,
-          expenses: acc.expenses + m.expenses,
+          bankExpenses: acc.bankExpenses + m.bankExpenses,
+          ccExpenses: acc.ccExpenses + m.ccExpenses,
+          ccCharge: acc.ccCharge + m.ccCharge,
           net: acc.net + m.net,
         }),
-        { income: 0, expenses: 0, net: 0 },
+        { income: 0, bankExpenses: 0, ccExpenses: 0, ccCharge: 0, net: 0 },
       );
 
       if (isJsonMode()) {
@@ -88,18 +90,20 @@ export function registerReportsCommand(program: Command): void {
       }
 
       const table = createTable(
-        ["Month", "Income", "Expenses", "Net", "Transactions"],
+        ["Month", "Income", "Bank Exp.", "CC Exp.", "CC Charge", "Net", "Txns"],
         months.map((m) => [
           m.month,
           formatCurrency(m.income),
-          formatCurrency(-m.expenses),
+          formatCurrency(-m.bankExpenses),
+          formatCurrency(-m.ccExpenses),
+          formatCurrency(-m.ccCharge),
           formatCurrency(m.net),
           String(m.transactionCount),
         ]),
       );
       console.log(table);
       info(
-        `\nTotals — Income: ${formatCurrency(totals.income)}, Expenses: ${formatCurrency(-totals.expenses)}, Net: ${formatCurrency(totals.net)}`,
+        `\nTotals — Income: ${formatCurrency(totals.income)}, Bank Exp: ${formatCurrency(-totals.bankExpenses)}, CC Exp: ${formatCurrency(-totals.ccExpenses)}, CC Charge: ${formatCurrency(-totals.ccCharge)}, Net: ${formatCurrency(totals.net)}`,
       );
     });
 

--- a/src/cli/commands/transactions.ts
+++ b/src/cli/commands/transactions.ts
@@ -10,7 +10,7 @@ import {
   countTransactions,
   deleteTransaction,
 } from "../../db/repositories/transactions.js";
-import type { TransactionWithContext } from "../../types/index.js";
+import { CC_BILLING_CATEGORY, type TransactionWithContext } from "../../types/index.js";
 import {
   isJsonMode,
   printJson,
@@ -33,9 +33,10 @@ function txRow(tx: TransactionWithContext, masked: boolean): string[] {
     tx.installmentTotal,
   );
   const displayDesc = tx.descriptionEn ?? tx.description;
+  const ccTag = tx.category === CC_BILLING_CATEGORY ? " [CC]" : "";
   const desc = installment
-    ? `${displayDesc} ${installment}`
-    : displayDesc;
+    ? `${displayDesc} ${installment}${ccTag}`
+    : `${displayDesc}${ccTag}`;
 
   return [
     formatDate(tx.date),

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -228,6 +228,14 @@ DELETE FROM accounts WHERE id IN (SELECT loser_id FROM _account_merges);
 DROP TABLE _account_merges;
 
 PRAGMA foreign_keys=ON;`],
+
+  ["008_cc_billing_category_rules.sql", `-- Seed CC billing category rules to prevent double-counting
+-- when both bank and CC providers are synced.
+-- Users can add more patterns via: kolshek categories add "CC Billing" "<pattern>"
+INSERT OR IGNORE INTO category_rules (category, match_pattern) VALUES
+  ('CC Billing', 'ויזה כאל'),
+  ('CC Billing', 'כאל'),
+  ('CC Billing', 'visa cal');`],
 ];
 
 // Run all pending SQL migrations.

--- a/src/db/repositories/reports.ts
+++ b/src/db/repositories/reports.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDatabase } from "../database.js";
+import { CC_BILLING_CATEGORY } from "../../types/transaction.js";
 
 export interface DateRange {
   from?: string;
@@ -46,7 +47,9 @@ function whereClause(conditions: string[]): string {
 export interface MonthlyRow {
   month: string;
   income: number;
-  expenses: number;
+  bankExpenses: number;
+  ccExpenses: number;
+  ccCharge: number;
   net: number;
   transactionCount: number;
 }
@@ -57,14 +60,22 @@ export function getMonthlyReport(
 ): MonthlyRow[] {
   const db = getDatabase();
   const { conditions, params } = buildDateConditions(range, providerType);
+  params.$ccBilling = CC_BILLING_CATEGORY;
 
   const sql = `
     SELECT
       strftime('%Y-%m', t.date) AS month,
       SUM(CASE WHEN t.charged_amount > 0 THEN t.charged_amount ELSE 0 END) AS income,
-      SUM(CASE WHEN t.charged_amount < 0 THEN ABS(t.charged_amount) ELSE 0 END) AS expenses,
-      SUM(t.charged_amount) AS net,
-      COUNT(*) AS transaction_count
+      SUM(CASE WHEN t.charged_amount < 0 AND p.type = 'bank'
+                AND COALESCE(t.category, '') != $ccBilling
+           THEN ABS(t.charged_amount) ELSE 0 END) AS bank_expenses,
+      SUM(CASE WHEN t.charged_amount < 0 AND p.type = 'credit_card'
+           THEN ABS(t.charged_amount) ELSE 0 END) AS cc_expenses,
+      SUM(CASE WHEN t.category = $ccBilling
+           THEN ABS(t.charged_amount) ELSE 0 END) AS cc_charge,
+      SUM(CASE WHEN COALESCE(t.category, '') != $ccBilling
+           THEN t.charged_amount ELSE 0 END) AS net,
+      COUNT(CASE WHEN COALESCE(t.category, '') != $ccBilling THEN 1 END) AS transaction_count
     FROM transactions t
     JOIN accounts a ON t.account_id = a.id
     JOIN providers p ON a.provider_id = p.id
@@ -76,7 +87,9 @@ export function getMonthlyReport(
   const rows = db.prepare(sql).all(params) as Array<{
     month: string;
     income: number;
-    expenses: number;
+    bank_expenses: number;
+    cc_expenses: number;
+    cc_charge: number;
     net: number;
     transaction_count: number;
   }>;
@@ -84,7 +97,9 @@ export function getMonthlyReport(
   return rows.map((r) => ({
     month: r.month,
     income: r.income,
-    expenses: r.expenses,
+    bankExpenses: r.bank_expenses,
+    ccExpenses: r.cc_expenses,
+    ccCharge: r.cc_charge,
     net: r.net,
     transactionCount: r.transaction_count,
   }));
@@ -107,9 +122,11 @@ export function getCategoryReport(
 ): CategoryRow[] {
   const db = getDatabase();
   const { conditions, params } = buildDateConditions(range, providerType);
+  params.$ccBilling = CC_BILLING_CATEGORY;
 
-  // Expenses only (charged_amount < 0)
+  // Expenses only, excluding CC billing (internal transfers)
   conditions.push("t.charged_amount < 0");
+  conditions.push("COALESCE(t.category, '') != $ccBilling");
 
   const sql = `
     SELECT
@@ -159,9 +176,11 @@ export function getMerchantReport(
 ): MerchantRow[] {
   const db = getDatabase();
   const { conditions, params } = buildDateConditions(range, providerType);
+  params.$ccBilling = CC_BILLING_CATEGORY;
 
-  // Expenses only
+  // Expenses only, excluding CC billing (internal transfers)
   conditions.push("t.charged_amount < 0");
+  conditions.push("COALESCE(t.category, '') != $ccBilling");
 
   params.$limit = limit;
 
@@ -228,6 +247,7 @@ export function getBalanceReport(): BalanceRow[] {
          FROM transactions t2
          WHERE t2.account_id = a.id
            AND t2.charged_amount < 0
+           AND COALESCE(t2.category, '') != 'CC Billing'
            AND t2.date >= date('now', '-30 days')),
         0
       ) AS recent_expenses_30d,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -2,6 +2,8 @@
  * Transaction types — maps closely to israeli-bank-scrapers Transaction.
  */
 
+export const CC_BILLING_CATEGORY = "CC Billing";
+
 export type TransactionType = "normal" | "installments";
 export type TransactionStatus = "completed" | "pending";
 


### PR DESCRIPTION
## Summary
- When both bank and CC providers are synced, the bank's monthly CC billing charge was double-counted as an expense alongside individual CC transactions
- Uses the existing category system with a reserved `"CC Billing"` category — no schema changes needed
- Monthly report now splits expenses into **Bank Exp / CC Exp / CC Charge** columns for reconciliation
- CC Billing excluded from category, merchant, and balance report expense totals
- Users can add rules for missed CC providers: `kolshek categories add "CC Billing" "<pattern>"`

## Changes
- **Migration 008**: Seeds Visa Cal category rules (`ויזה כאל`, `כאל`, `visa cal`)
- **Reports**: Monthly report shows bank/CC expense breakdown; CC billing excluded from all expense sums
- **Transactions**: `[CC]` tag shown for billing charges in `tx list`
- **Plugin skills**: All 6 categorize skills updated with CC billing detection guidance

## Test plan
- [ ] `bun run typecheck` passes (verified)
- [ ] `bun test` — 89 tests pass (verified)
- [ ] `kolshek fetch` re-categorizes existing CC billing transactions
- [ ] `kolshek reports monthly` shows Bank Exp / CC Exp / CC Charge columns
- [ ] `kolshek reports categories` excludes CC Billing from expense breakdown
- [ ] `kolshek tx list` shows `[CC]` tag on billing charges
- [ ] `kolshek categories add "CC Billing" "ישראכרט"` works for user-added patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)