### PR TITLE
Fix shell quoting bugs and add bulk translation rule import

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ kolshek cat rule add "Groceries" --match "שופרסל"
 # Translate a Hebrew merchant name
 kolshek tr rule add "Shufersal" --match "שופרסל"
 
+# Bulk-import translation rules from JSON (safe for names with apostrophes)
+echo '[{"englishName":"Ouri'\''s Market","matchPattern":"אורי מרקט"}]' | kolshek tr rule import
+kolshek tr rule import rules.json
+
 # Seed common Israeli merchant translations
 kolshek tr seed
 

--- a/src/cli/commands/translate.ts
+++ b/src/cli/commands/translate.ts
@@ -9,6 +9,7 @@ import {
   removeTranslationRule,
   applyTranslationRules,
   seedTranslationRules,
+  bulkImportTranslationRules,
 } from "../../db/repositories/translations.js";
 import { MERCHANT_NAMES } from "../../core/merchant-names.js";
 import {
@@ -120,6 +121,80 @@ export function registerTranslateCommand(program: Command): void {
         printError("NOT_FOUND", `Rule #${id} not found`);
         process.exit(ExitCode.BadArgs);
       }
+    });
+
+  // --- translate rule import ---
+  ruleCmd
+    .command("import [file]")
+    .description(
+      "Bulk-import translation rules from a JSON file or stdin. " +
+      'Format: [{"englishName": "...", "matchPattern": "..."}]',
+    )
+    .action(async (filePath?: string) => {
+      let rawJson: string;
+
+      if (filePath) {
+        const file = Bun.file(filePath);
+        if (!(await file.exists())) {
+          printError("NOT_FOUND", `File not found: ${filePath}`);
+          process.exit(ExitCode.BadArgs);
+        }
+        rawJson = await file.text();
+      } else {
+        if (process.stdin.isTTY) {
+          printError(
+            "BAD_ARGS",
+            "No file specified and stdin is a terminal. " +
+            "Pipe JSON or provide a file path.\n" +
+            '  Example: echo \'[{"englishName":"Store","matchPattern":"חנות"}]\' | kolshek tr rule import',
+          );
+          process.exit(ExitCode.BadArgs);
+        }
+        rawJson = await new Response(Bun.stdin.stream()).text();
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawJson);
+      } catch {
+        printError("BAD_ARGS", "Invalid JSON input");
+        process.exit(ExitCode.BadArgs);
+      }
+
+      if (!Array.isArray(parsed)) {
+        printError("BAD_ARGS", "JSON must be an array of rule objects");
+        process.exit(ExitCode.BadArgs);
+      }
+
+      const rules: Array<{ englishName: string; matchPattern: string }> = [];
+      for (const [i, entry] of parsed.entries()) {
+        if (
+          typeof entry !== "object" || entry === null ||
+          typeof (entry as Record<string, unknown>).englishName !== "string" ||
+          typeof (entry as Record<string, unknown>).matchPattern !== "string"
+        ) {
+          printError(
+            "BAD_ARGS",
+            `Invalid rule at index ${i}: each entry needs "englishName" and "matchPattern" strings`,
+          );
+          process.exit(ExitCode.BadArgs);
+        }
+        const e = entry as { englishName: string; matchPattern: string };
+        if (!e.matchPattern.trim() || !e.englishName.trim()) {
+          printError("BAD_ARGS", `Empty name or pattern at index ${i}`);
+          process.exit(ExitCode.BadArgs);
+        }
+        rules.push({ englishName: e.englishName, matchPattern: e.matchPattern });
+      }
+
+      const result = bulkImportTranslationRules(rules);
+
+      if (isJsonMode()) {
+        printJson(jsonSuccess(result));
+        return;
+      }
+
+      success(`Imported ${result.imported} rule(s), skipped ${result.skipped} duplicate(s).`);
     });
 
   // --- translate apply ---

--- a/src/core/scheduler/escape.ts
+++ b/src/core/scheduler/escape.ts
@@ -1,0 +1,23 @@
+// Escape the five XML predefined entities so arbitrary strings
+// can be safely embedded in XML text or attribute values.
+export function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Wrap a string in single quotes for safe embedding in shell contexts
+// (crontab lines, etc). Embedded single quotes become '\'' which
+// closes the quote, adds an escaped literal quote, and reopens.
+export function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+// Escape a string for use inside systemd ExecStart= double-quoted values.
+// Systemd uses C-style quoting: backslash and double-quote must be escaped.
+export function systemdEscape(s: string): string {
+  return '"' + s.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}

--- a/src/core/scheduler/linux.ts
+++ b/src/core/scheduler/linux.ts
@@ -8,6 +8,7 @@ import { mkdir, unlink } from "node:fs/promises";
 import type { ScheduleConfig } from "../../types/index.js";
 import type { SchedulerBackend } from "./index.js";
 import { run } from "./index.js";
+import { shellQuote, systemdEscape } from "./escape.js";
 
 const UNIT_NAME = "kolshek-fetch";
 const SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
@@ -21,7 +22,7 @@ Description=KolShek automatic fetch
 
 [Service]
 Type=oneshot
-ExecStart=${config.binaryPath} fetch --non-interactive
+ExecStart=${systemdEscape(config.binaryPath)} fetch --non-interactive
 `;
 }
 
@@ -97,7 +98,7 @@ async function cronRegister(config: ScheduleConfig): Promise<void> {
   // Remove existing kolshek entry if any
   const lines = existing.split("\n").filter((l) => !l.includes(CRON_MARKER));
   const cronExpr = `0 */${config.intervalHours} * * *`;
-  lines.push(`${cronExpr} ${config.binaryPath} fetch --non-interactive ${CRON_MARKER}`);
+  lines.push(`${cronExpr} ${shellQuote(config.binaryPath)} fetch --non-interactive ${CRON_MARKER}`);
   const newCrontab = lines.filter((l) => l.trim()).join("\n") + "\n";
   await run(["crontab", "-"], newCrontab);
 }

--- a/src/core/scheduler/macos.ts
+++ b/src/core/scheduler/macos.ts
@@ -9,6 +9,7 @@ import { mkdir, unlink } from "node:fs/promises";
 import type { ScheduleConfig } from "../../types/index.js";
 import type { SchedulerBackend } from "./index.js";
 import { run } from "./index.js";
+import { escapeXml } from "./escape.js";
 
 const LABEL = "com.kolshek.fetch";
 const PLIST_DIR = join(homedir(), "Library", "LaunchAgents");
@@ -25,7 +26,7 @@ function buildPlist(config: ScheduleConfig): string {
     <string>${LABEL}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${config.binaryPath}</string>
+        <string>${escapeXml(config.binaryPath)}</string>
         <string>fetch</string>
         <string>--non-interactive</string>
     </array>
@@ -34,9 +35,9 @@ function buildPlist(config: ScheduleConfig): string {
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>${LOG_PATH}</string>
+    <string>${escapeXml(LOG_PATH)}</string>
     <key>StandardErrorPath</key>
-    <string>${LOG_PATH}</string>
+    <string>${escapeXml(LOG_PATH)}</string>
 </dict>
 </plist>`;
 }

--- a/src/core/scheduler/windows.ts
+++ b/src/core/scheduler/windows.ts
@@ -9,13 +9,13 @@ import { unlink } from "node:fs/promises";
 import type { ScheduleConfig } from "../../types/index.js";
 import type { SchedulerBackend } from "./index.js";
 import { run } from "./index.js";
+import { escapeXml } from "./escape.js";
 
 const TASK_NAME = "KolShek Fetch";
 
 function buildTaskXml(config: ScheduleConfig): string {
   const interval = `PT${config.intervalHours}H`;
-  // Escape XML entities in binary path
-  const cmd = config.binaryPath.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  const cmd = escapeXml(config.binaryPath);
 
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">

--- a/src/db/repositories/translations.ts
+++ b/src/db/repositories/translations.ts
@@ -90,6 +90,41 @@ export function applyTranslationRules(): { applied: number } {
   return { applied };
 }
 
+export interface TranslationRuleInput {
+  englishName: string;
+  matchPattern: string;
+}
+
+export function bulkImportTranslationRules(
+  rules: TranslationRuleInput[],
+): { imported: number; skipped: number } {
+  const db = getDatabase();
+  let imported = 0;
+  let skipped = 0;
+
+  const insertStmt = db.prepare(
+    `INSERT INTO translation_rules (english_name, match_pattern)
+     SELECT $englishName, $pattern
+     WHERE NOT EXISTS (
+       SELECT 1 FROM translation_rules WHERE match_pattern = $pattern
+     )`,
+  );
+
+  for (const rule of rules) {
+    const result = insertStmt.run({
+      $englishName: rule.englishName,
+      $pattern: rule.matchPattern,
+    });
+    if (result.changes > 0) {
+      imported++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return { imported, skipped };
+}
+
 export function seedTranslationRules(
   entries: Record<string, string>,
 ): { seeded: number } {

--- a/tests/unit/escape.test.ts
+++ b/tests/unit/escape.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { escapeXml, shellQuote, systemdEscape } from "../../src/core/scheduler/escape.js";
+
+describe("escapeXml", () => {
+  it("escapes ampersands", () => {
+    expect(escapeXml("H&M")).toBe("H&amp;M");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeXml("<script>")).toBe("&lt;script&gt;");
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeXml('say "hello"')).toBe("say &quot;hello&quot;");
+  });
+
+  it("escapes single quotes", () => {
+    expect(escapeXml("O'Reilly")).toBe("O&apos;Reilly");
+  });
+
+  it("handles multiple entities in one string", () => {
+    expect(escapeXml('a&b<c>d"e\'f')).toBe("a&amp;b&lt;c&gt;d&quot;e&apos;f");
+  });
+
+  it("passes through strings with no special chars", () => {
+    expect(escapeXml("/usr/local/bin/kolshek")).toBe("/usr/local/bin/kolshek");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeXml("")).toBe("");
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps simple path in single quotes", () => {
+    expect(shellQuote("/usr/bin/kolshek")).toBe("'/usr/bin/kolshek'");
+  });
+
+  it("handles spaces in path", () => {
+    expect(shellQuote("/home/user/my programs/kolshek")).toBe("'/home/user/my programs/kolshek'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it("handles dollar signs", () => {
+    expect(shellQuote("$HOME/bin")).toBe("'$HOME/bin'");
+  });
+
+  it("handles backticks", () => {
+    expect(shellQuote("`whoami`")).toBe("'`whoami`'");
+  });
+
+  it("handles empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+});
+
+describe("systemdEscape", () => {
+  it("wraps simple path in double quotes", () => {
+    expect(systemdEscape("/usr/bin/kolshek")).toBe('"/usr/bin/kolshek"');
+  });
+
+  it("handles spaces in path", () => {
+    expect(systemdEscape("/opt/my app/kolshek")).toBe('"/opt/my app/kolshek"');
+  });
+
+  it("escapes embedded backslashes", () => {
+    expect(systemdEscape("C:\\Program Files\\kolshek")).toBe('"C:\\\\Program Files\\\\kolshek"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(systemdEscape('path/"quoted"/bin')).toBe('"path/\\"quoted\\"/bin"');
+  });
+
+  it("handles empty string", () => {
+    expect(systemdEscape("")).toBe('""');
+  });
+});

--- a/tests/unit/translate-import.test.ts
+++ b/tests/unit/translate-import.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { initDatabase, closeDatabase } from "../../src/db/database.js";
+import {
+  bulkImportTranslationRules,
+  listTranslationRules,
+} from "../../src/db/repositories/translations.js";
+
+beforeAll(() => {
+  initDatabase(":memory:");
+});
+
+afterAll(() => {
+  closeDatabase();
+});
+
+describe("bulkImportTranslationRules", () => {
+  it("imports an array of rules", () => {
+    const result = bulkImportTranslationRules([
+      { englishName: "Shufersal", matchPattern: "שופרסל" },
+      { englishName: "Rami Levy", matchPattern: "רמי לוי" },
+    ]);
+    expect(result.imported).toBe(2);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("skips duplicates by matchPattern", () => {
+    const result = bulkImportTranslationRules([
+      { englishName: "Shufersal", matchPattern: "שופרסל" },
+      { englishName: "New Entry", matchPattern: "חדש" },
+    ]);
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("handles apostrophes in englishName", () => {
+    const result = bulkImportTranslationRules([
+      { englishName: "Ouri's Market", matchPattern: "אורי מרקט" },
+    ]);
+    expect(result.imported).toBe(1);
+    const rules = listTranslationRules();
+    const match = rules.find((r) => r.matchPattern === "אורי מרקט");
+    expect(match?.englishName).toBe("Ouri's Market");
+  });
+
+  it("handles quotes and special punctuation", () => {
+    const result = bulkImportTranslationRules([
+      { englishName: "Ben & Jerry's", matchPattern: "בן אנד ג׳ריס" },
+    ]);
+    expect(result.imported).toBe(1);
+    const rules = listTranslationRules();
+    const match = rules.find((r) => r.matchPattern === "בן אנד ג׳ריס");
+    expect(match?.englishName).toBe("Ben & Jerry's");
+  });
+
+  it("handles empty array", () => {
+    const result = bulkImportTranslationRules([]);
+    expect(result.imported).toBe(0);
+    expect(result.skipped).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix scheduler quoting bugs**: Binary paths containing spaces, quotes, or special characters now properly escaped in systemd service files (`systemdEscape`), crontab entries (`shellQuote`), and macOS plist XML (`escapeXml`)
- **Shared escape utilities**: Extract `escapeXml`, `shellQuote`, and `systemdEscape` into `src/core/scheduler/escape.ts`; refactor all three scheduler backends to use them
- **Add `translate rule import [file]` command**: Bulk-import translation rules from a JSON file or stdin, bypassing shell quoting entirely for merchant names with apostrophes or punctuation

Closes #5

## Test plan

- [ ] `bun test` — all 112 tests pass (including new escape + bulk import tests)
- [ ] `bun test tests/unit/escape.test.ts` — escapeXml, shellQuote, systemdEscape edge cases
- [ ] `bun test tests/unit/translate-import.test.ts` — bulk import with apostrophes, ampersands, duplicates
- [ ] Manual: `echo '[{"englishName":"Ouri'\''s Market","matchPattern":"אורי"}]' | bun run dev -- tr rule import`
- [ ] Manual: `bun run dev -- tr rule list` shows rule with apostrophe intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)