### PR TITLE
feat(categorize): multi-field rule engine

### DIFF
--- a/src/cli/commands/categorize.ts
+++ b/src/cli/commands/categorize.ts
@@ -2,6 +2,7 @@
 
 import type { Command } from "commander";
 import { z } from "zod";
+import type { RuleConditions, CategoryRuleInput } from "../../types/index.js";
 import {
   addCategoryRule,
   listCategoryRules,
@@ -14,6 +15,7 @@ import {
   bulkMigrateCategoriesDryRun,
   bulkImportCategoryRules,
 } from "../../db/repositories/categories.js";
+import { formatConditions } from "../../core/rules.js";
 import {
   isJsonMode,
   printJson,
@@ -25,6 +27,39 @@ import {
   formatCurrency,
   ExitCode,
 } from "../output.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for conditions validation
+// ---------------------------------------------------------------------------
+
+const textMatchSchema = z.object({
+  pattern: z.string().min(1),
+  mode: z.enum(["substring", "exact", "regex"]).default("substring"),
+});
+
+const amountMatchSchema = z.object({
+  exact: z.number().optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+}).refine(
+  (a) => a.exact !== undefined || a.min !== undefined || a.max !== undefined,
+  { message: "Amount must have at least one of exact, min, or max" },
+);
+
+const ruleConditionsSchema = z.object({
+  description: textMatchSchema.optional(),
+  memo: textMatchSchema.optional(),
+  account: z.string().min(1).optional(),
+  amount: amountMatchSchema.optional(),
+  direction: z.enum(["debit", "credit"]).optional(),
+}).refine(
+  (c) => c.description || c.memo || c.account || c.amount || c.direction,
+  { message: "At least one condition is required" },
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 async function readJsonFile(filePath: string): Promise<unknown> {
   const file = Bun.file(filePath);
@@ -39,6 +74,50 @@ async function readJsonFile(filePath: string): Promise<unknown> {
     throw new Error(`Invalid JSON in ${filePath}`);
   }
 }
+
+// Build RuleConditions from CLI flags
+function buildConditionsFromOpts(opts: Record<string, unknown>): RuleConditions | null {
+  const conditions: RuleConditions = {};
+
+  if (opts.match) {
+    conditions.description = { pattern: String(opts.match), mode: "substring" };
+  } else if (opts.matchExact) {
+    conditions.description = { pattern: String(opts.matchExact), mode: "exact" };
+  } else if (opts.matchRegex) {
+    conditions.description = { pattern: String(opts.matchRegex), mode: "regex" };
+  }
+
+  if (opts.memo) {
+    conditions.memo = { pattern: String(opts.memo), mode: "substring" };
+  }
+
+  if (opts.account) {
+    conditions.account = String(opts.account);
+  }
+
+  // Amount: --amount for exact, --amount-min / --amount-max for range
+  if (opts.amount !== undefined) {
+    conditions.amount = { exact: Number(opts.amount) };
+  } else if (opts.amountMin !== undefined || opts.amountMax !== undefined) {
+    const amount: { min?: number; max?: number } = {};
+    if (opts.amountMin !== undefined) amount.min = Number(opts.amountMin);
+    if (opts.amountMax !== undefined) amount.max = Number(opts.amountMax);
+    conditions.amount = amount;
+  }
+
+  if (opts.direction) {
+    conditions.direction = String(opts.direction) as "debit" | "credit";
+  }
+
+  // Return null if no conditions were provided
+  const hasAny = conditions.description || conditions.memo || conditions.account
+    || conditions.amount || conditions.direction;
+  return hasAny ? conditions : null;
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
 
 export function registerCategorizeCommand(program: Command): void {
   const catCmd = program
@@ -55,28 +134,50 @@ export function registerCategorizeCommand(program: Command): void {
   ruleCmd
     .command("add <category>")
     .description("Create a category rule")
-    .requiredOption("--match <pattern>", "Substring pattern to match against description")
+    .option("--match <pattern>", "Substring match on description")
+    .option("--match-exact <pattern>", "Exact match on description")
+    .option("--match-regex <pattern>", "Regex match on description")
+    .option("--memo <pattern>", "Substring match on memo")
+    .option("--account <account>", "Account filter (e.g. 'leumi:12345' or '12345')")
+    .option("--amount <number>", "Exact amount match", parseFloat)
+    .option("--amount-min <number>", "Minimum amount (inclusive)", parseFloat)
+    .option("--amount-max <number>", "Maximum amount (inclusive)", parseFloat)
+    .option("--direction <dir>", "Direction filter: debit or credit")
+    .option("--priority <number>", "Rule priority (higher = evaluated first)", parseInt, 0)
     .action((category: string, opts) => {
-      const pattern = String(opts.match);
-      if (!pattern.trim()) {
-        printError("BAD_ARGS", "Match pattern cannot be empty");
+      const conditions = buildConditionsFromOpts(opts);
+
+      if (!conditions) {
+        printError("BAD_ARGS", "At least one condition is required (--match, --account, --amount, --direction, etc.)");
         process.exit(ExitCode.BadArgs);
       }
 
-      const rule = addCategoryRule(category, pattern);
+      // Validate conditions with Zod
+      const parsed = ruleConditionsSchema.safeParse(conditions);
+      if (!parsed.success) {
+        printError("BAD_ARGS", parsed.error.issues[0].message);
+        process.exit(ExitCode.BadArgs);
+      }
+
+      const priority = Number(opts.priority) || 0;
+      const rule = addCategoryRule(category, parsed.data, priority);
 
       if (isJsonMode()) {
         printJson(
           jsonSuccess({
             id: rule.id,
             category: rule.category,
-            matchPattern: rule.matchPattern,
+            conditions: rule.conditions,
+            priority: rule.priority,
           }),
         );
         return;
       }
 
-      success(`Rule #${rule.id} created: "${pattern}" → ${category}`);
+      success(`Rule #${rule.id} created: ${formatConditions(rule.conditions)} → ${category}`);
+      if (rule.priority !== 0) {
+        info(`  Priority: ${rule.priority}`);
+      }
     });
 
   // --- categorize rule list ---
@@ -97,11 +198,12 @@ export function registerCategorizeCommand(program: Command): void {
       }
 
       const table = createTable(
-        ["ID", "Category", "Match Pattern", "Created"],
+        ["ID", "Pri", "Category", "Conditions", "Created"],
         rules.map((r) => [
           String(r.id),
+          String(r.priority),
           r.category,
-          r.matchPattern,
+          formatConditions(r.conditions),
           r.createdAt,
         ]),
       );
@@ -145,7 +247,7 @@ export function registerCategorizeCommand(program: Command): void {
     .command("import [file]")
     .description(
       "Bulk-import category rules from a JSON file or stdin. " +
-      'Format: [{"category": "...", "matchPattern": "..."}]',
+      "Accepts both legacy format [{category, matchPattern}] and new format [{category, conditions, priority?}]",
     )
     .action(async (filePath?: string) => {
       let rawJson: string;
@@ -163,7 +265,7 @@ export function registerCategorizeCommand(program: Command): void {
             "BAD_ARGS",
             "No file specified and stdin is a terminal. " +
             "Pipe JSON or provide a file path.\n" +
-            '  Example: echo \'[{"category":"Groceries","matchPattern":"שופרסל"}]\' | kolshek cat rule import',
+            '  Example: echo \'[{"category":"Groceries","conditions":{"description":{"pattern":"שופרסל","mode":"substring"}}}]\' | kolshek cat rule import',
           );
           process.exit(ExitCode.BadArgs);
         }
@@ -183,25 +285,47 @@ export function registerCategorizeCommand(program: Command): void {
         process.exit(ExitCode.BadArgs);
       }
 
-      const rules: Array<{ category: string; matchPattern: string }> = [];
+      const rules: CategoryRuleInput[] = [];
       for (const [i, entry] of parsed.entries()) {
-        if (
-          typeof entry !== "object" || entry === null ||
-          typeof (entry as Record<string, unknown>).category !== "string" ||
-          typeof (entry as Record<string, unknown>).matchPattern !== "string"
-        ) {
+        if (typeof entry !== "object" || entry === null) {
+          printError("BAD_ARGS", `Invalid rule at index ${i}: must be an object`);
+          process.exit(ExitCode.BadArgs);
+        }
+
+        const e = entry as Record<string, unknown>;
+
+        if (!e.category || typeof e.category !== "string" || !e.category.trim()) {
+          printError("BAD_ARGS", `Missing or empty "category" at index ${i}`);
+          process.exit(ExitCode.BadArgs);
+        }
+
+        // Detect format: legacy (matchPattern) vs new (conditions)
+        if (e.conditions) {
+          // New format: validate conditions with Zod
+          const condParsed = ruleConditionsSchema.safeParse(e.conditions);
+          if (!condParsed.success) {
+            printError("BAD_ARGS", `Invalid conditions at index ${i}: ${condParsed.error.issues[0].message}`);
+            process.exit(ExitCode.BadArgs);
+          }
+          rules.push({
+            category: e.category as string,
+            conditions: condParsed.data,
+            priority: typeof e.priority === "number" ? e.priority : 0,
+          });
+        } else if (e.matchPattern && typeof e.matchPattern === "string" && e.matchPattern.trim()) {
+          // Legacy format: convert to conditions
+          rules.push({
+            category: e.category as string,
+            conditions: { description: { pattern: e.matchPattern as string, mode: "substring" } },
+            priority: typeof e.priority === "number" ? e.priority : 0,
+          });
+        } else {
           printError(
             "BAD_ARGS",
-            `Invalid rule at index ${i}: each entry needs "category" and "matchPattern" strings`,
+            `Rule at index ${i} needs either "conditions" or "matchPattern"`,
           );
           process.exit(ExitCode.BadArgs);
         }
-        const e = entry as { category: string; matchPattern: string };
-        if (!e.matchPattern.trim() || !e.category.trim()) {
-          printError("BAD_ARGS", `Empty category or pattern at index ${i}`);
-          process.exit(ExitCode.BadArgs);
-        }
-        rules.push({ category: e.category, matchPattern: e.matchPattern });
       }
 
       const result = bulkImportCategoryRules(rules);

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -1,0 +1,158 @@
+// Pure rule evaluation engine. No DB or CLI imports.
+
+import type {
+  RuleConditions,
+  TextMatch,
+  AmountMatch,
+  CategoryRule,
+  TransactionForMatching,
+} from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Individual matchers
+// ---------------------------------------------------------------------------
+
+function matchesText(
+  condition: TextMatch,
+  ...values: (string | null)[]
+): boolean {
+  for (const value of values) {
+    if (value == null) continue;
+    switch (condition.mode) {
+      case "exact":
+        if (value === condition.pattern) return true;
+        break;
+      case "regex":
+        try {
+          if (new RegExp(condition.pattern, "i").test(value)) return true;
+        } catch {
+          // invalid regex — treat as non-match
+        }
+        break;
+      case "substring":
+      default: {
+        const lower = value.toLowerCase();
+        const pat = condition.pattern.toLowerCase();
+        if (lower.includes(pat)) return true;
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+function matchesAccount(condition: string, providerAlias: string, accountNumber: string): boolean {
+  // "alias:accountNumber" format
+  if (condition.includes(":")) {
+    const sepIdx = condition.indexOf(":");
+    const alias = condition.slice(0, sepIdx);
+    const accNum = condition.slice(sepIdx + 1);
+    return providerAlias === alias && accountNumber === accNum;
+  }
+  // plain account number
+  return accountNumber === condition;
+}
+
+function matchesAmount(condition: AmountMatch, chargedAmount: number): boolean {
+  if (condition.exact !== undefined && chargedAmount !== condition.exact) return false;
+  if (condition.min !== undefined && chargedAmount < condition.min) return false;
+  if (condition.max !== undefined && chargedAmount > condition.max) return false;
+  return true;
+}
+
+function matchesDirection(direction: "debit" | "credit", chargedAmount: number): boolean {
+  if (direction === "debit") return chargedAmount < 0;
+  return chargedAmount > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Rule evaluation
+// ---------------------------------------------------------------------------
+
+// Evaluate a single rule against a transaction. All present conditions AND'd.
+export function evaluateRule(
+  conditions: RuleConditions,
+  tx: TransactionForMatching,
+): boolean {
+  if (conditions.description) {
+    if (!matchesText(conditions.description, tx.description, tx.descriptionEn)) return false;
+  }
+  if (conditions.memo) {
+    if (!matchesText(conditions.memo, tx.memo)) return false;
+  }
+  if (conditions.account) {
+    if (!matchesAccount(conditions.account, tx.providerAlias, tx.accountNumber)) return false;
+  }
+  if (conditions.amount) {
+    if (!matchesAmount(conditions.amount, tx.chargedAmount)) return false;
+  }
+  if (conditions.direction) {
+    if (!matchesDirection(conditions.direction, tx.chargedAmount)) return false;
+  }
+  return true;
+}
+
+// Apply rules to transactions. Returns Map<transactionId, category>.
+// Rules must already be sorted by priority DESC, id ASC. First match wins.
+export function applyRules(
+  rules: CategoryRule[],
+  transactions: TransactionForMatching[],
+): Map<number, string> {
+  const result = new Map<number, string>();
+  for (const tx of transactions) {
+    for (const rule of rules) {
+      if (evaluateRule(rule.conditions, tx)) {
+        result.set(tx.id, rule.category);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable conditions formatter
+// ---------------------------------------------------------------------------
+
+function formatTextMatch(prefix: string, m: TextMatch): string {
+  switch (m.mode) {
+    case "exact":
+      return `${prefix}="${m.pattern}"`;
+    case "regex":
+      return `${prefix}/${m.pattern}/`;
+    case "substring":
+    default:
+      return `${prefix}~"${m.pattern}"`;
+  }
+}
+
+export function formatConditions(conditions: RuleConditions): string {
+  const parts: string[] = [];
+
+  if (conditions.description) {
+    parts.push(formatTextMatch("desc", conditions.description));
+  }
+  if (conditions.memo) {
+    parts.push(formatTextMatch("memo", conditions.memo));
+  }
+  if (conditions.account) {
+    parts.push(`account:${conditions.account}`);
+  }
+  if (conditions.amount) {
+    const a = conditions.amount;
+    if (a.exact !== undefined) {
+      parts.push(`amount:${a.exact}`);
+    } else if (a.min !== undefined && a.max !== undefined) {
+      parts.push(`amount:${a.min}..${a.max}`);
+    } else if (a.min !== undefined) {
+      parts.push(`amount>=${a.min}`);
+    } else if (a.max !== undefined) {
+      parts.push(`amount<=${a.max}`);
+    }
+  }
+  if (conditions.direction) {
+    parts.push(`dir:${conditions.direction}`);
+  }
+
+  return parts.join(" AND ");
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -230,6 +230,29 @@ DROP TABLE _account_merges;
 PRAGMA foreign_keys=ON;`],
 
   ["008_cc_billing_category_rules.sql", `SELECT 1; -- removed: seed rules no longer auto-inserted`],
+
+  ["009_multi_field_rules.sql", `-- Upgrade category_rules to multi-field JSON conditions + priority.
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE category_rules_v2 (
+  id INTEGER PRIMARY KEY,
+  category TEXT NOT NULL,
+  conditions TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO category_rules_v2 (id, category, conditions, priority, created_at)
+  SELECT id, category,
+    json_object('description', json_object('pattern', match_pattern, 'mode', 'substring')),
+    0,
+    created_at
+  FROM category_rules;
+
+DROP TABLE category_rules;
+ALTER TABLE category_rules_v2 RENAME TO category_rules;
+
+PRAGMA foreign_keys=ON;`],
 ];
 
 // Run all pending SQL migrations.

--- a/src/db/migrations/009_multi_field_rules.sql
+++ b/src/db/migrations/009_multi_field_rules.sql
@@ -1,0 +1,22 @@
+-- Upgrade category_rules to multi-field JSON conditions + priority.
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE category_rules_v2 (
+  id INTEGER PRIMARY KEY,
+  category TEXT NOT NULL,
+  conditions TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO category_rules_v2 (id, category, conditions, priority, created_at)
+  SELECT id, category,
+    json_object('description', json_object('pattern', match_pattern, 'mode', 'substring')),
+    0,
+    created_at
+  FROM category_rules;
+
+DROP TABLE category_rules;
+ALTER TABLE category_rules_v2 RENAME TO category_rules;
+
+PRAGMA foreign_keys=ON;

--- a/src/db/repositories/categories.ts
+++ b/src/db/repositories/categories.ts
@@ -1,20 +1,24 @@
-/**
- * Category rule CRUD and application logic.
- */
+// Category rule CRUD and application logic.
+// Rules use a JSON conditions column for multi-field matching.
 
 import { getDatabase } from "../database.js";
+import type {
+  RuleConditions,
+  CategoryRule,
+  CategoryRuleInput,
+  TransactionForMatching,
+} from "../../types/index.js";
+import { applyRules as applyRulesEngine } from "../../core/rules.js";
 
-export interface CategoryRule {
-  id: number;
-  category: string;
-  matchPattern: string;
-  createdAt: string;
-}
+// ---------------------------------------------------------------------------
+// DB row type and mapper
+// ---------------------------------------------------------------------------
 
 interface CategoryRuleRow {
   id: number;
   category: string;
-  match_pattern: string;
+  conditions: string; // JSON string
+  priority: number;
   created_at: string;
 }
 
@@ -22,23 +26,40 @@ function rowToRule(row: CategoryRuleRow): CategoryRule {
   return {
     id: row.id,
     category: row.category,
-    matchPattern: row.match_pattern,
+    conditions: JSON.parse(row.conditions) as RuleConditions,
+    priority: row.priority,
     createdAt: row.created_at,
   };
 }
 
-/** Escape SQL LIKE wildcards so they are treated as literals. */
-function escapeLike(s: string): string {
-  return s.replace(/[%_\\]/g, "\\$&");
+// Deterministic JSON serialization for dedup comparisons.
+function serializeConditions(conditions: RuleConditions): string {
+  const sorted: Record<string, unknown> = {};
+  // Fixed key order
+  if (conditions.description) sorted.description = conditions.description;
+  if (conditions.memo) sorted.memo = conditions.memo;
+  if (conditions.account) sorted.account = conditions.account;
+  if (conditions.amount) sorted.amount = conditions.amount;
+  if (conditions.direction) sorted.direction = conditions.direction;
+  return JSON.stringify(sorted);
 }
 
-export function addCategoryRule(category: string, pattern: string): CategoryRule {
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export function addCategoryRule(
+  category: string,
+  conditions: RuleConditions,
+  priority: number = 0,
+): CategoryRule {
   const db = getDatabase();
+  const conditionsJson = serializeConditions(conditions);
   const result = db
     .prepare(
-      "INSERT INTO category_rules (category, match_pattern) VALUES ($category, $pattern)",
+      "INSERT INTO category_rules (category, conditions, priority) VALUES ($category, $conditions, $priority)",
     )
-    .run({ $category: category, $pattern: pattern });
+    .run({ $category: category, $conditions: conditionsJson, $priority: priority });
 
   const row = db
     .prepare("SELECT * FROM category_rules WHERE id = $id")
@@ -50,7 +71,7 @@ export function addCategoryRule(category: string, pattern: string): CategoryRule
 export function listCategoryRules(): CategoryRule[] {
   const db = getDatabase();
   const rows = db
-    .prepare("SELECT * FROM category_rules ORDER BY id")
+    .prepare("SELECT * FROM category_rules ORDER BY priority DESC, id ASC")
     .all() as CategoryRuleRow[];
 
   return rows.map(rowToRule);
@@ -65,29 +86,76 @@ export function removeCategoryRule(id: number): boolean {
   return result.changes > 0;
 }
 
+// ---------------------------------------------------------------------------
+// Apply rules to uncategorized transactions (in-memory evaluation)
+// ---------------------------------------------------------------------------
+
+interface UncategorizedTxRow {
+  id: number;
+  description: string;
+  description_en: string | null;
+  memo: string | null;
+  charged_amount: number;
+  provider_alias: string;
+  account_number: string;
+}
+
 export function applyCategoryRules(): { applied: number; uncategorized: number } {
   const db = getDatabase();
-  const rules = db
-    .prepare("SELECT * FROM category_rules ORDER BY id")
+
+  // 1. Fetch rules in evaluation order
+  const ruleRows = db
+    .prepare("SELECT * FROM category_rules ORDER BY priority DESC, id ASC")
     .all() as CategoryRuleRow[];
+  const rules = ruleRows.map(rowToRule);
 
+  // 2. Fetch uncategorized transactions with account/provider context
+  const txRows = db
+    .prepare(
+      `SELECT
+         t.id, t.description, t.description_en, t.memo, t.charged_amount,
+         p.alias AS provider_alias,
+         a.account_number
+       FROM transactions t
+       JOIN accounts a ON t.account_id = a.id
+       JOIN providers p ON a.provider_id = p.id
+       WHERE t.category IS NULL OR t.category = 'Uncategorized'`,
+    )
+    .all() as UncategorizedTxRow[];
+
+  const transactions: TransactionForMatching[] = txRows.map((r) => ({
+    id: r.id,
+    description: r.description,
+    descriptionEn: r.description_en,
+    memo: r.memo,
+    chargedAmount: r.charged_amount,
+    providerAlias: r.provider_alias,
+    accountNumber: r.account_number,
+  }));
+
+  // 3. Evaluate rules in-memory
+  const assignments = applyRulesEngine(rules, transactions);
+
+  // 4. Batch-update matched transactions
   let applied = 0;
-
-  for (const rule of rules) {
-    const pattern = `%${escapeLike(rule.match_pattern)}%`;
-    const result = db
-      .prepare(
-        `UPDATE transactions
-         SET category = $category, updated_at = datetime('now')
-         WHERE (category IS NULL OR category = 'Uncategorized')
-           AND (description LIKE $pattern ESCAPE '\\' OR description_en LIKE $pattern ESCAPE '\\')`,
-      )
-      .run({ $category: rule.category, $pattern: pattern });
-
-    applied += result.changes;
+  if (assignments.size > 0) {
+    const updateStmt = db.prepare(
+      "UPDATE transactions SET category = $category, updated_at = datetime('now') WHERE id = $id",
+    );
+    db.run("BEGIN");
+    try {
+      for (const [txId, category] of assignments) {
+        updateStmt.run({ $id: txId, $category: category });
+        applied++;
+      }
+      db.run("COMMIT");
+    } catch (err) {
+      db.run("ROLLBACK");
+      throw err;
+    }
   }
 
-  // Set remaining NULLs to 'Uncategorized'
+  // 5. Set remaining NULLs to 'Uncategorized'
   const uncatResult = db
     .prepare(
       "UPDATE transactions SET category = 'Uncategorized', updated_at = datetime('now') WHERE category IS NULL",
@@ -96,6 +164,10 @@ export function applyCategoryRules(): { applied: number; uncategorized: number }
 
   return { applied, uncategorized: uncatResult.changes };
 }
+
+// ---------------------------------------------------------------------------
+// Category summary
+// ---------------------------------------------------------------------------
 
 export interface CategorySummary {
   category: string;
@@ -167,7 +239,6 @@ export function renameCategoryDryRun(
   newName: string,
 ): { transactionsAffected: number; rulesAffected: number } {
   const db = getDatabase();
-  // newName is accepted for API consistency but unused in dry-run counts
   void newName;
 
   const txRow = db
@@ -270,11 +341,6 @@ export function bulkMigrateCategoriesDryRun(
 // Bulk rule import
 // ---------------------------------------------------------------------------
 
-export interface CategoryRuleInput {
-  category: string;
-  matchPattern: string;
-}
-
 export function bulkImportCategoryRules(
   rules: CategoryRuleInput[],
 ): { imported: number; skipped: number } {
@@ -283,17 +349,19 @@ export function bulkImportCategoryRules(
   let skipped = 0;
 
   const insertStmt = db.prepare(
-    `INSERT INTO category_rules (category, match_pattern)
-     SELECT $category, $pattern
+    `INSERT INTO category_rules (category, conditions, priority)
+     SELECT $category, $conditions, $priority
      WHERE NOT EXISTS (
-       SELECT 1 FROM category_rules WHERE match_pattern = $pattern
+       SELECT 1 FROM category_rules WHERE conditions = $conditions
      )`,
   );
 
   for (const rule of rules) {
+    const conditionsJson = serializeConditions(rule.conditions);
     const result = insertStmt.run({
       $category: rule.category,
-      $pattern: rule.matchPattern,
+      $conditions: conditionsJson,
+      $priority: rule.priority ?? 0,
     });
     if (result.changes > 0) {
       imported++;

--- a/src/types/category-rule.ts
+++ b/src/types/category-rule.ts
@@ -1,0 +1,48 @@
+// Category rule types for the multi-field rule engine.
+
+export type MatchMode = "substring" | "exact" | "regex";
+
+export interface TextMatch {
+  pattern: string;
+  mode: MatchMode;
+}
+
+export interface AmountMatch {
+  exact?: number;
+  min?: number;
+  max?: number;
+}
+
+// All present fields are AND'd together. At least one condition required.
+export interface RuleConditions {
+  description?: TextMatch;
+  memo?: TextMatch;
+  account?: string; // "providerAlias:accountNumber" or just "accountNumber"
+  amount?: AmountMatch;
+  direction?: "debit" | "credit";
+}
+
+export interface CategoryRule {
+  id: number;
+  category: string;
+  conditions: RuleConditions;
+  priority: number;
+  createdAt: string;
+}
+
+export interface CategoryRuleInput {
+  category: string;
+  conditions: RuleConditions;
+  priority?: number;
+}
+
+// Minimal transaction shape needed for rule evaluation (keeps core/ pure).
+export interface TransactionForMatching {
+  id: number;
+  description: string;
+  descriptionEn: string | null;
+  memo: string | null;
+  chargedAmount: number;
+  providerAlias: string;
+  accountNumber: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./account.js";
 export * from "./transaction.js";
 export * from "./config.js";
 export * from "./schedule.js";
+export * from "./category-rule.js";

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -517,8 +517,8 @@ describe("category rename and migration", () => {
     db.prepare("UPDATE transactions SET category = 'Delivery' WHERE description = 'Wolt'").run();
 
     // Add a category rule for Food
-    addCategoryRule("Food", "שופרסל");
-    addCategoryRule("Telecom", "HOT");
+    addCategoryRule("Food", { description: { pattern: "שופרסל", mode: "substring" } });
+    addCategoryRule("Telecom", { description: { pattern: "HOT", mode: "substring" } });
   });
 
   it("dry-run returns correct counts without modifying data", () => {
@@ -546,7 +546,7 @@ describe("category rename and migration", () => {
     expect(groceryCount.count).toBe(2);
 
     // Verify rule was updated
-    const ruleRow = db.prepare("SELECT category FROM category_rules WHERE match_pattern = 'שופרסל'").get() as { category: string };
+    const ruleRow = db.prepare("SELECT category FROM category_rules WHERE conditions LIKE '%שופרסל%'").get() as { category: string };
     expect(ruleRow.category).toBe("Groceries");
   });
 
@@ -605,9 +605,9 @@ describe("category rename and migration", () => {
 describe("category rule import", () => {
   it("imports new rules and skips duplicates", () => {
     const result = bulkImportCategoryRules([
-      { category: "Transport", matchPattern: "דן" },
-      { category: "Transport", matchPattern: "אגד" },
-      { category: "Entertainment", matchPattern: "Netflix" },
+      { category: "Transport", conditions: { description: { pattern: "דן", mode: "substring" } } },
+      { category: "Transport", conditions: { description: { pattern: "אגד", mode: "substring" } } },
+      { category: "Entertainment", conditions: { description: { pattern: "Netflix", mode: "substring" } } },
     ]);
 
     expect(result.imported).toBe(3);
@@ -615,8 +615,8 @@ describe("category rule import", () => {
 
     // Import again — all should be skipped
     const result2 = bulkImportCategoryRules([
-      { category: "Transport", matchPattern: "דן" },
-      { category: "Transport", matchPattern: "אגד" },
+      { category: "Transport", conditions: { description: { pattern: "דן", mode: "substring" } } },
+      { category: "Transport", conditions: { description: { pattern: "אגד", mode: "substring" } } },
     ]);
     expect(result2.imported).toBe(0);
     expect(result2.skipped).toBe(2);

--- a/tests/unit/rules.test.ts
+++ b/tests/unit/rules.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from "vitest";
+import { evaluateRule, applyRules, formatConditions } from "../../src/core/rules.js";
+import type {
+  RuleConditions,
+  CategoryRule,
+  TransactionForMatching,
+} from "../../src/types/index.js";
+
+// Helper to build a minimal transaction for matching
+function makeTx(overrides: Partial<TransactionForMatching> = {}): TransactionForMatching {
+  return {
+    id: 1,
+    description: "שופרסל דיל",
+    descriptionEn: "Shufersal Deal",
+    memo: null,
+    chargedAmount: -150.0,
+    providerAlias: "leumi",
+    accountNumber: "12345",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Description matching
+// ---------------------------------------------------------------------------
+
+describe("description matching", () => {
+  it("substring match (Hebrew)", () => {
+    const cond: RuleConditions = { description: { pattern: "שופרסל", mode: "substring" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("substring match (English, case-insensitive)", () => {
+    const cond: RuleConditions = { description: { pattern: "shufersal", mode: "substring" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("substring match against description_en", () => {
+    const cond: RuleConditions = { description: { pattern: "Deal", mode: "substring" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("substring no match", () => {
+    const cond: RuleConditions = { description: { pattern: "רמי לוי", mode: "substring" } };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("exact match", () => {
+    const cond: RuleConditions = { description: { pattern: "שופרסל דיל", mode: "exact" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("exact match fails on partial", () => {
+    const cond: RuleConditions = { description: { pattern: "שופרסל", mode: "exact" } };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("regex match", () => {
+    const cond: RuleConditions = { description: { pattern: "שופרסל.*דיל", mode: "regex" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("regex match is case-insensitive", () => {
+    const cond: RuleConditions = { description: { pattern: "SHUFERSAL", mode: "regex" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("invalid regex treated as non-match (no throw)", () => {
+    const cond: RuleConditions = { description: { pattern: "[invalid", mode: "regex" } };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("matches description_en when description does not match", () => {
+    const cond: RuleConditions = { description: { pattern: "Shufersal Deal", mode: "exact" } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("null description_en is skipped, matches description", () => {
+    const tx = makeTx({ descriptionEn: null });
+    const cond: RuleConditions = { description: { pattern: "שופרסל", mode: "substring" } };
+    expect(evaluateRule(cond, tx)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Memo matching
+// ---------------------------------------------------------------------------
+
+describe("memo matching", () => {
+  it("substring match on memo", () => {
+    const cond: RuleConditions = { memo: { pattern: "branch", mode: "substring" } };
+    const tx = makeTx({ memo: "Branch 42" });
+    expect(evaluateRule(cond, tx)).toBe(true);
+  });
+
+  it("null memo returns false", () => {
+    const cond: RuleConditions = { memo: { pattern: "branch", mode: "substring" } };
+    expect(evaluateRule(cond, makeTx({ memo: null }))).toBe(false);
+  });
+
+  it("regex on memo", () => {
+    const cond: RuleConditions = { memo: { pattern: "branch \\d+", mode: "regex" } };
+    const tx = makeTx({ memo: "Branch 42" });
+    expect(evaluateRule(cond, tx)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Account matching
+// ---------------------------------------------------------------------------
+
+describe("account matching", () => {
+  it("matches alias:accountNumber", () => {
+    const cond: RuleConditions = { account: "leumi:12345" };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("fails on wrong alias", () => {
+    const cond: RuleConditions = { account: "hapoalim:12345" };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("fails on wrong account number", () => {
+    const cond: RuleConditions = { account: "leumi:99999" };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("matches plain account number (no alias)", () => {
+    const cond: RuleConditions = { account: "12345" };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("plain account number fails on mismatch", () => {
+    const cond: RuleConditions = { account: "99999" };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Amount matching
+// ---------------------------------------------------------------------------
+
+describe("amount matching", () => {
+  it("exact amount match", () => {
+    const cond: RuleConditions = { amount: { exact: -150 } };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("exact amount mismatch", () => {
+    const cond: RuleConditions = { amount: { exact: -100 } };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("min amount (inclusive)", () => {
+    const cond: RuleConditions = { amount: { min: -200 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -150 }))).toBe(true);
+  });
+
+  it("min amount excludes lower", () => {
+    const cond: RuleConditions = { amount: { min: -100 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -150 }))).toBe(false);
+  });
+
+  it("max amount (inclusive)", () => {
+    const cond: RuleConditions = { amount: { max: -100 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -150 }))).toBe(true);
+  });
+
+  it("max amount excludes higher", () => {
+    const cond: RuleConditions = { amount: { max: -200 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -150 }))).toBe(false);
+  });
+
+  it("range match (min and max)", () => {
+    const cond: RuleConditions = { amount: { min: -200, max: -100 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -150 }))).toBe(true);
+  });
+
+  it("range excludes outside", () => {
+    const cond: RuleConditions = { amount: { min: -200, max: -100 } };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -50 }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direction matching
+// ---------------------------------------------------------------------------
+
+describe("direction matching", () => {
+  it("debit matches negative amount", () => {
+    const cond: RuleConditions = { direction: "debit" };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -100 }))).toBe(true);
+  });
+
+  it("debit fails on positive", () => {
+    const cond: RuleConditions = { direction: "debit" };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: 100 }))).toBe(false);
+  });
+
+  it("credit matches positive amount", () => {
+    const cond: RuleConditions = { direction: "credit" };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: 500 }))).toBe(true);
+  });
+
+  it("credit fails on negative", () => {
+    const cond: RuleConditions = { direction: "credit" };
+    expect(evaluateRule(cond, makeTx({ chargedAmount: -500 }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AND logic (multiple conditions)
+// ---------------------------------------------------------------------------
+
+describe("AND logic", () => {
+  it("all conditions must match", () => {
+    const cond: RuleConditions = {
+      description: { pattern: "שופרסל", mode: "substring" },
+      direction: "debit",
+      account: "leumi:12345",
+    };
+    expect(evaluateRule(cond, makeTx())).toBe(true);
+  });
+
+  it("fails if any condition fails", () => {
+    const cond: RuleConditions = {
+      description: { pattern: "שופרסל", mode: "substring" },
+      direction: "credit", // mismatch: tx is debit
+    };
+    expect(evaluateRule(cond, makeTx())).toBe(false);
+  });
+
+  it("complex multi-field rule", () => {
+    const cond: RuleConditions = {
+      description: { pattern: "Check", mode: "exact" },
+      account: "leumi:948-85326_77",
+      amount: { exact: -6500 },
+      direction: "debit",
+    };
+    const tx = makeTx({
+      description: "Check",
+      descriptionEn: null,
+      chargedAmount: -6500,
+      providerAlias: "leumi",
+      accountNumber: "948-85326_77",
+    });
+    expect(evaluateRule(cond, tx)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRules — priority and first-match-wins
+// ---------------------------------------------------------------------------
+
+describe("applyRules", () => {
+  const txs: TransactionForMatching[] = [
+    makeTx({ id: 1, description: "שופרסל דיל", chargedAmount: -150 }),
+    makeTx({ id: 2, description: "Netflix", descriptionEn: "Netflix", chargedAmount: -49.9 }),
+    makeTx({ id: 3, description: "salary", descriptionEn: "Salary", chargedAmount: 15000 }),
+  ];
+
+  it("first matching rule wins (by priority DESC, then id ASC)", () => {
+    const rules: CategoryRule[] = [
+      { id: 2, category: "Entertainment", conditions: { description: { pattern: "Netflix", mode: "substring" } }, priority: 10, createdAt: "" },
+      { id: 1, category: "Groceries", conditions: { description: { pattern: "שופרסל", mode: "substring" } }, priority: 5, createdAt: "" },
+      { id: 3, category: "Income", conditions: { direction: "credit" }, priority: 0, createdAt: "" },
+    ];
+
+    const result = applyRules(rules, txs);
+    expect(result.get(1)).toBe("Groceries");
+    expect(result.get(2)).toBe("Entertainment");
+    expect(result.get(3)).toBe("Income");
+  });
+
+  it("unmatched transactions are not in the map", () => {
+    const rules: CategoryRule[] = [
+      { id: 1, category: "Groceries", conditions: { description: { pattern: "שופרסל", mode: "substring" } }, priority: 0, createdAt: "" },
+    ];
+
+    const result = applyRules(rules, txs);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(2)).toBe(false);
+    expect(result.has(3)).toBe(false);
+  });
+
+  it("higher priority rule wins even with higher id", () => {
+    const rules: CategoryRule[] = [
+      { id: 10, category: "Specific Grocery", conditions: { description: { pattern: "שופרסל", mode: "substring" }, amount: { exact: -150 } }, priority: 10, createdAt: "" },
+      { id: 1, category: "General Grocery", conditions: { description: { pattern: "שופרסל", mode: "substring" } }, priority: 0, createdAt: "" },
+    ];
+
+    const result = applyRules(rules, [txs[0]]);
+    expect(result.get(1)).toBe("Specific Grocery");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatConditions
+// ---------------------------------------------------------------------------
+
+describe("formatConditions", () => {
+  it("substring description", () => {
+    expect(formatConditions({ description: { pattern: "שופרסל", mode: "substring" } }))
+      .toBe('desc~"שופרסל"');
+  });
+
+  it("exact description", () => {
+    expect(formatConditions({ description: { pattern: "Netflix", mode: "exact" } }))
+      .toBe('desc="Netflix"');
+  });
+
+  it("regex description", () => {
+    expect(formatConditions({ description: { pattern: "net.*flix", mode: "regex" } }))
+      .toBe("desc/net.*flix/");
+  });
+
+  it("multiple conditions joined with AND", () => {
+    const cond: RuleConditions = {
+      description: { pattern: "Check", mode: "exact" },
+      account: "leumi:12345",
+      direction: "debit",
+    };
+    expect(formatConditions(cond)).toBe('desc="Check" AND account:leumi:12345 AND dir:debit');
+  });
+
+  it("amount range", () => {
+    expect(formatConditions({ amount: { min: -200, max: -100 } }))
+      .toBe("amount:-200..-100");
+  });
+
+  it("amount exact", () => {
+    expect(formatConditions({ amount: { exact: -6500 } }))
+      .toBe("amount:-6500");
+  });
+
+  it("amount min only", () => {
+    expect(formatConditions({ amount: { min: -500 } }))
+      .toBe("amount>=-500");
+  });
+
+  it("amount max only", () => {
+    expect(formatConditions({ amount: { max: -100 } }))
+      .toBe("amount<=-100");
+  });
+
+  it("memo condition", () => {
+    expect(formatConditions({ memo: { pattern: "branch", mode: "substring" } }))
+      .toBe('memo~"branch"');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace simple LIKE-based description matching with a full multi-field rule engine
- Rules can now match on: description (substring/exact/regex), memo, account, amount (exact/range), direction (debit/credit)
- All conditions are AND'd together; priority ordering controls evaluation order
- Pure evaluation engine in `src/core/rules.ts` (no DB/CLI imports, honors core/ purity)
- Migration 009 auto-converts existing rules to the new JSON conditions format
- CLI gains new flags: `--match-exact`, `--match-regex`, `--memo`, `--account`, `--amount`, `--amount-min`, `--amount-max`, `--direction`, `--priority`
- Import command accepts both legacy `{matchPattern}` and new `{conditions}` format
- 46 new unit tests for the rule engine, all 167 tests pass

## Test plan
- [ ] `bun run dev -- categorize rule add "Rent" --match "Check" --account "leumi:948" --amount -6500 --direction debit`
- [ ] `bun run dev -- categorize rule list` — verify conditions + priority columns display
- [ ] `bun run dev -- categorize rule list --json` — verify full conditions in JSON output
- [ ] `bun run dev -- categorize apply` — verify multi-field matching works
- [ ] `echo '[{"category":"X","matchPattern":"old"}]' | bun run dev -- cat rule import` — legacy format
- [ ] `bun test` — all 167 tests pass
- [ ] Verify existing DB with old-format rules migrates correctly on first run

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)