### PR TITLE
feat(analysis): add spending, income, trends, and insights commands

### DIFF
--- a/plugin/CONTEXT.md
+++ b/plugin/CONTEXT.md
@@ -64,6 +64,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -73,7 +78,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -109,7 +127,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -127,6 +147,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -135,7 +157,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -159,6 +181,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/agents/finance-assistant.md
+++ b/plugin/agents/finance-assistant.md
@@ -55,3 +55,103 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - When showing spending, negative amounts are expenses, positive are income/refunds.
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
+
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `/kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```

--- a/plugin/integrations/aider/CONVENTIONS.md
+++ b/plugin/integrations/aider/CONVENTIONS.md
@@ -71,6 +71,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -80,7 +85,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -116,7 +134,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -134,6 +154,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -142,7 +164,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -166,6 +188,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 
@@ -231,6 +300,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - When showing spending, negative amounts are expenses, positive are income/refunds.
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
+
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
 
 ---
 
@@ -742,8 +911,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -769,6 +939,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 ```
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
+
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -1008,8 +1184,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 

--- a/plugin/integrations/antigravity/kolshek-budget-app/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-budget-app/SKILL.md
@@ -3,7 +3,7 @@ name: kolshek-budget-app
 description: Design and build a personal budget dashboard powered by your KolShek transaction data.
 risk: low
 source: community
-date_added: '2026-03-10'
+date_added: '2026-03-13'
 ---
 
 # kolshek:budget-app
@@ -563,6 +563,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -572,7 +577,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -608,7 +626,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -626,6 +646,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -634,7 +656,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -658,6 +680,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/antigravity/kolshek-categorize/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-categorize/SKILL.md
@@ -3,7 +3,7 @@ name: kolshek-categorize
 description: Analyze your transactions and set up category rules for expenses and income.
 risk: low
 source: community
-date_added: '2026-03-10'
+date_added: '2026-03-13'
 ---
 
 # kolshek:categorize
@@ -12,8 +12,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -42,9 +43,9 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 
 ### CC Billing Detection
 
-If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
 
-Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -160,6 +161,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -169,7 +175,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -205,7 +224,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -223,6 +244,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -231,7 +254,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -255,6 +278,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/antigravity/kolshek-finance-assistant/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-finance-assistant/SKILL.md
@@ -3,7 +3,7 @@ name: kolshek-finance-assistant
 description: Use when user asks about transactions, spending, budgets, balances, bank accounts, Israeli finance, financial analysis, or wants to work with their kolshek data.
 risk: low
 source: community
-date_added: '2026-03-10'
+date_added: '2026-03-13'
 ---
 
 # Finance Assistant
@@ -50,6 +50,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - When showing spending, negative amounts are expenses, positive are income/refunds.
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
+
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
 
 ---
 
@@ -120,6 +220,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -129,7 +234,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -165,7 +283,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -183,6 +303,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -191,7 +313,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -215,6 +337,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/antigravity/kolshek-init/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-init/SKILL.md
@@ -3,7 +3,7 @@ name: kolshek-init
 description: Set up KolShek — connect your bank accounts, fetch transactions, and get your data ready.
 risk: low
 source: community
-date_added: '2026-03-10'
+date_added: '2026-03-13'
 ---
 
 # kolshek:init
@@ -246,6 +246,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -255,7 +260,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -291,7 +309,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -309,6 +329,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -317,7 +339,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -341,6 +363,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/antigravity/kolshek-translate/SKILL.md
+++ b/plugin/integrations/antigravity/kolshek-translate/SKILL.md
@@ -3,7 +3,7 @@ name: kolshek-translate
 description: Translate Hebrew transaction descriptions to English.
 risk: low
 source: community
-date_added: '2026-03-10'
+date_added: '2026-03-13'
 ---
 
 # kolshek:translate
@@ -12,8 +12,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 
@@ -145,6 +144,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -154,7 +158,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -190,7 +207,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -208,6 +227,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -216,7 +237,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -240,6 +261,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/cursor/rules/kolshek-budget-app.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-budget-app.mdc
@@ -561,6 +561,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -570,7 +575,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -606,7 +624,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -624,6 +644,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -632,7 +654,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -656,6 +678,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/cursor/rules/kolshek-categorize.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-categorize.mdc
@@ -10,8 +10,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -40,9 +41,9 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 
 ### CC Billing Detection
 
-If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
 
-Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -158,6 +159,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -167,7 +173,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -203,7 +222,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -221,6 +242,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -229,7 +252,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -253,6 +276,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/cursor/rules/kolshek-finance-assistant.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-finance-assistant.mdc
@@ -49,6 +49,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
 
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
+
 ---
 
 # Reference: KolShek CLI
@@ -118,6 +218,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -127,7 +232,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -163,7 +281,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -181,6 +301,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -189,7 +311,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -213,6 +335,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/cursor/rules/kolshek-init.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-init.mdc
@@ -244,6 +244,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -253,7 +258,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -289,7 +307,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -307,6 +327,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -315,7 +337,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -339,6 +361,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/cursor/rules/kolshek-translate.mdc
+++ b/plugin/integrations/cursor/rules/kolshek-translate.mdc
@@ -10,8 +10,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 
@@ -143,6 +142,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -152,7 +156,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -188,7 +205,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -206,6 +225,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -214,7 +235,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -238,6 +259,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/gemini-cli/skills/kolshek-budget-app/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-budget-app/SKILL.md
@@ -560,6 +560,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -569,7 +574,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -605,7 +623,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -623,6 +643,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -631,7 +653,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -655,6 +677,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/gemini-cli/skills/kolshek-categorize/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-categorize/SKILL.md
@@ -9,8 +9,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -39,9 +40,9 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 
 ### CC Billing Detection
 
-If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
 
-Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -157,6 +158,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -166,7 +172,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -202,7 +221,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -220,6 +241,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -228,7 +251,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -252,6 +275,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/gemini-cli/skills/kolshek-finance-assistant/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-finance-assistant/SKILL.md
@@ -48,6 +48,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
 
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
+
 ---
 
 # Reference: KolShek CLI
@@ -117,6 +217,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -126,7 +231,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -162,7 +280,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -180,6 +300,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -188,7 +310,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -212,6 +334,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/gemini-cli/skills/kolshek-init/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-init/SKILL.md
@@ -243,6 +243,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -252,7 +257,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -288,7 +306,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -306,6 +326,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -314,7 +336,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -338,6 +360,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/gemini-cli/skills/kolshek-translate/SKILL.md
+++ b/plugin/integrations/gemini-cli/skills/kolshek-translate/SKILL.md
@@ -9,8 +9,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 
@@ -142,6 +141,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -151,7 +155,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -187,7 +204,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -205,6 +224,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -213,7 +234,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -237,6 +258,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/opencode/agent/kolshek-budget-app.md
+++ b/plugin/integrations/opencode/agent/kolshek-budget-app.md
@@ -561,6 +561,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -570,7 +575,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -606,7 +624,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -624,6 +644,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -632,7 +654,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -656,6 +678,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/opencode/agent/kolshek-categorize.md
+++ b/plugin/integrations/opencode/agent/kolshek-categorize.md
@@ -10,8 +10,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -40,9 +41,9 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 
 ### CC Billing Detection
 
-If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
 
-Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -158,6 +159,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -167,7 +173,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -203,7 +222,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -221,6 +242,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -229,7 +252,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -253,6 +276,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/opencode/agent/kolshek-finance-assistant.md
+++ b/plugin/integrations/opencode/agent/kolshek-finance-assistant.md
@@ -49,6 +49,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
 
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
+
 ---
 
 # Reference: KolShek CLI
@@ -118,6 +218,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -127,7 +232,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -163,7 +281,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -181,6 +301,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -189,7 +311,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -213,6 +335,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/opencode/agent/kolshek-init.md
+++ b/plugin/integrations/opencode/agent/kolshek-init.md
@@ -244,6 +244,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -253,7 +258,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -289,7 +307,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -307,6 +327,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -315,7 +337,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -339,6 +361,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/opencode/agent/kolshek-translate.md
+++ b/plugin/integrations/opencode/agent/kolshek-translate.md
@@ -10,8 +10,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 
@@ -143,6 +142,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -152,7 +156,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -188,7 +205,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -206,6 +225,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -214,7 +235,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -238,6 +259,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 

--- a/plugin/integrations/windsurf/.windsurfrules
+++ b/plugin/integrations/windsurf/.windsurfrules
@@ -71,6 +71,11 @@ kolshek categorize rule list [--json]
 kolshek categorize rule remove <id> [--json]
 kolshek categorize apply [--json]
 kolshek categorize list [--json]
+kolshek categorize rename <old> <new> [--dry-run] [--json]
+kolshek categorize migrate --file <path> [--dry-run] [--json]
+kolshek categorize reassign --match <pattern> --to <category> [--dry-run] [--json]
+kolshek categorize reassign --file <path> [--dry-run] [--json]
+kolshek categorize rule import [file] [--json]
 ```
 
 ### Translation (Hebrew→English)
@@ -80,7 +85,20 @@ kolshek translate rule list [--json]
 kolshek translate rule remove <id> [--json]
 kolshek translate apply [--json]
 kolshek translate seed [--json]
+kolshek translate rule import [file] [--json]
 ```
+
+### Spending & Income Analysis
+```
+kolshek spending [month] [--group-by <category|merchant|provider>] [--category <name>] [--top <n>] [--type] [--json]
+kolshek income [month] [--salary-only] [--include-refunds] [--json]
+kolshek trends [months] [--mode <total|category|fixed-variable>] [--category <name>] [--type] [--json]
+kolshek insights [--months <n>] [--json]
+```
+
+Month formats: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+**Income defaults to bank accounts only** — CC positive amounts are refunds, not income. Use `--include-refunds` to see them.
 
 ### Reports
 ```
@@ -116,7 +134,9 @@ kolshek init [--json]              # interactive wizard — loops to add multipl
 
 ### Date Formats
 
-All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+All `--from`/`--to` date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 30 days).
+
+Month arguments (spending, income, trends) accept: `current`, `prev`, `-3` (3 months ago), `2026-03`.
 
 ### Exit Codes
 
@@ -134,6 +154,8 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 
 **Sign convention:** negative `charged_amount` = expense, positive = income/refund.
 
+**CC Billing:** Transactions categorized as `"CC Billing"` are internal bank-to-CC transfers. Report commands auto-exclude them. When writing custom SQL for expenses, add `AND COALESCE(category, '') != 'CC Billing'` to avoid double-counting.
+
 **`authenticated` field:** appears in `kolshek providers list --json` output but is NOT a DB column — it's computed at runtime by checking the OS keychain.
 
 ### Tables
@@ -142,7 +164,7 @@ All date flags accept: `YYYY-MM-DD`, `DD/MM/YYYY`, or relative like `30d` (last 
 - **accounts** — discovered accounts (`id`, `provider_id`, `account_number`, `display_name`, `balance`, `currency`, `created_at`)
 - **transactions** — all scraped transactions (`id`, `account_id`, `type`, `identifier`, `date`, `processed_date`, `original_amount`, `original_currency`, `charged_amount`, `charged_currency`, `description`, `description_en`, `memo`, `status`, `installment_number`, `installment_total`, `category`, `hash`, `unique_id`, `created_at`, `updated_at`)
 - **sync_log** — fetch history (`id`, `provider_id`, `started_at`, `completed_at`, `status`, `transactions_added`, `transactions_updated`, `error_message`, `scrape_start_date`, `scrape_end_date`)
-- **category_rules** — auto-categorization rules (`id`, `category`, `match_pattern`, `created_at`)
+- **category_rules** — auto-categorization rules (`id`, `category`, `conditions` (JSON), `priority`, `created_at`)
 - **translation_rules** — Hebrew→English translations (`id`, `english_name`, `match_pattern`, `created_at`)
 
 ### Common SQL Patterns
@@ -166,6 +188,53 @@ GROUP BY date ORDER BY date;
 ```
 
 Always run `kolshek db schema <table>` first to verify column names before writing queries.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query "<sql>" --json`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries:
+
+```sql
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Installment obligations
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+```
+
+## Skill Startup Checks
+
+All skills should run these checks before starting work:
+
+1. **Providers configured:** `kolshek providers list --json` — if empty, guide user to `kolshek providers add`. If any show `authenticated: false`, tell user to run `kolshek providers auth <id>`.
+2. **Transaction data exists:** `kolshek transactions list --limit 1 --json` — if empty, offer to fetch.
+3. **Data freshness:** `kolshek query "SELECT MAX(completed_at) as last_sync FROM sync_log WHERE status = 'success'" --json` — if over 24h old, suggest `kolshek fetch`.
 
 ## User Configuration
 
@@ -231,6 +300,106 @@ If the user wants to build something (dashboard, script, report, bot), suggest t
 - When showing spending, negative amounts are expenses, positive are income/refunds.
 - Proactively surface insights: "Your grocery spending is 20% higher than last month."
 - If the user seems to be exploring, suggest relevant reports or analyses.
+
+## Command Decision Tree
+
+Pick the right command on the first try:
+
+| User wants... | Best command | When to use SQL instead |
+|---|---|---|
+| Spending by category/merchant/provider | `kolshek spending [month] --group-by <field> --json` | Never — spending handles it |
+| Monthly cashflow breakdown | `kolshek reports monthly --from 90d --json` | Never — splits bank vs CC |
+| Multi-month trends | `kolshek trends 6 --json` | Never — computes MoM % |
+| Category trend over time | `kolshek trends --category Groceries --json` | Never |
+| Fixed vs variable expenses | `kolshek trends --mode fixed-variable --json` | Never |
+| Income / salary breakdown | `kolshek income [month] --json` | Never — auto-classifies salary |
+| Financial alerts | `kolshek insights --json` | Never — runs 5 detectors |
+| Top merchants by spend | `kolshek reports merchants --from 30d --limit 20 --json` | Never |
+| Account balances | `kolshek reports balance --json` | Never |
+| Search for a merchant | `kolshek transactions search "query" --from 90d --json` | Never |
+| Category rules status | `kolshek categorize list --json` | Never |
+| Day-of-week analysis | SQL | No built-in command for this |
+| Recurring subscriptions | SQL | No built-in command for this |
+| Installment obligations | SQL | No built-in command for this |
+| Custom cross-table analysis | SQL | When built-in commands can't answer |
+
+**Month formats** for spending/income/trends: `current`, `prev`, `-3`, `2026-03`, or omit for current month.
+
+## Data Freshness Check
+
+After the Setup check, also run:
+```
+kolshek query "SELECT MAX(completed_at) as last_sync, COUNT(DISTINCT provider_id) as providers_synced FROM sync_log WHERE status = 'success'" --json
+```
+
+If `last_sync` is more than 24 hours ago, warn the user:
+> Your data was last synced on {date}. Run `kolshek fetch` to get the latest transactions before analysis.
+
+## Translation-First Guidance
+
+Before categorizing, check if translations exist:
+```
+kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json
+```
+
+If many descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than Hebrew ones.
+
+## Direct SQL — Escape Hatch
+
+When built-in commands can't answer the question, use `kolshek query`:
+- **Read-only** — only SELECT, WITH, EXPLAIN, PRAGMA are allowed
+- **Auto-LIMIT** — defaults to 100 rows if no LIMIT clause
+- **Schema discovery** — run `kolshek db tables` then `kolshek db schema <table>` first
+
+Example queries for common agent tasks:
+
+```sql
+-- Spending by day of week
+SELECT CASE CAST(strftime('%w', date) AS INTEGER)
+  WHEN 0 THEN 'Sun' WHEN 1 THEN 'Mon' WHEN 2 THEN 'Tue'
+  WHEN 3 THEN 'Wed' WHEN 4 THEN 'Thu' WHEN 5 THEN 'Fri'
+  WHEN 6 THEN 'Sat' END AS day,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total,
+  ROUND(AVG(ABS(charged_amount)), 2) AS avg_txn
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-90 days')
+GROUP BY strftime('%w', date) ORDER BY total DESC
+
+-- Find recurring subscriptions (same merchant+amount, 3+ months)
+SELECT COALESCE(description_en, description) AS merchant,
+  ROUND(ABS(charged_amount), 2) AS amount,
+  COUNT(DISTINCT strftime('%Y-%m', date)) AS months
+FROM transactions WHERE charged_amount < 0
+  AND date >= date('now', '-180 days')
+GROUP BY merchant, ROUND(ABS(charged_amount), 2)
+HAVING months >= 3 ORDER BY amount DESC
+
+-- Installment obligations (what's left to pay)
+SELECT COALESCE(description_en, description) AS merchant,
+  installment_number, installment_total,
+  ROUND(ABS(charged_amount), 2) AS payment,
+  (installment_total - installment_number) AS remaining
+FROM transactions WHERE installment_total > 1
+  AND date >= date('now', '-30 days')
+ORDER BY payment DESC
+
+-- Month-over-month comparison for a category
+SELECT strftime('%Y-%m', date) AS month,
+  ROUND(SUM(ABS(charged_amount)), 2) AS total
+FROM transactions WHERE charged_amount < 0
+  AND category = 'Groceries'
+  AND date >= date('now', '-180 days')
+GROUP BY month ORDER BY month
+
+-- Income sources (bank accounts only)
+SELECT COALESCE(description_en, description) AS source,
+  ROUND(SUM(charged_amount), 2) AS total, COUNT(*) AS times
+FROM transactions t JOIN accounts a ON t.account_id = a.id
+  JOIN providers p ON a.provider_id = p.id
+WHERE t.charged_amount > 0 AND p.type = 'bank'
+  AND t.date >= date('now', '-90 days')
+GROUP BY source ORDER BY total DESC
+```
 
 ================================================================================
 ## Skill: kolshek:budget-app
@@ -738,8 +907,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -765,6 +935,12 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 ```
 kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as total FROM transactions WHERE charged_amount > 0 AND (category IS NULL OR category = '') GROUP BY description ORDER BY count DESC" --json
 ```
+
+### CC Billing Detection
+
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 
@@ -1000,8 +1176,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 

--- a/plugin/skills/categorize/SKILL.md
+++ b/plugin/skills/categorize/SKILL.md
@@ -11,8 +11,9 @@ You are helping the user categorize their transactions. This covers both expense
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then:
+
+**Translation check:** Run `kolshek query "SELECT COUNT(*) as total, SUM(CASE WHEN description_en IS NOT NULL THEN 1 ELSE 0 END) as translated FROM transactions" --json`. If most descriptions lack `description_en`, suggest running `/kolshek:translate` first — categorizing English descriptions is more reliable than raw Hebrew.
 
 ## Step 1: Show Current State
 
@@ -41,9 +42,9 @@ kolshek query "SELECT description, COUNT(*) as count, SUM(charged_amount) as tot
 
 ### CC Billing Detection
 
-If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names (e.g., "ויזה כאל", "כאל", "ישראכרט", "מקס", "אמריקן אקספרס", "visa cal"). These are **CC billing charges** — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
+If the user has both bank and credit card providers, look for uncategorized bank transactions whose descriptions match credit card company names. These are CC billing charges — the monthly bank debit that pays the CC bill. They are internal transfers, not real expenses, and cause double-counting since the CC provider already tracks individual purchases.
 
-Suggest categorizing these as `"CC Billing"` (exact string). Reports automatically exclude `"CC Billing"` from expense totals.
+Suggest to the user that these transactions be categorized as `"CC Billing"` (exact string) — but let the user decide. Reports automatically exclude `"CC Billing"` from expense totals.
 
 ## Step 3: Suggest Categories
 

--- a/plugin/skills/translate/SKILL.md
+++ b/plugin/skills/translate/SKILL.md
@@ -11,8 +11,7 @@ You are helping the user translate their Hebrew transaction descriptions to Engl
 
 ## Before You Start
 
-1. Run `kolshek providers list --json` — if no providers, tell the user to run `kolshek providers add` in their terminal. Wait and re-check.
-2. Run `kolshek transactions list --limit 1 --json` — if no transactions, offer to fetch: "No transaction data yet. Want me to fetch it now?" If yes, run `kolshek fetch --json`.
+Run the standard Skill Startup Checks (see CONTEXT.md reference). Then continue to Step 1.
 
 ## Step 1: Seed Built-In Dictionary
 

--- a/src/cli/commands/income.ts
+++ b/src/cli/commands/income.ts
@@ -1,0 +1,68 @@
+// kolshek income — Income view with salary detection.
+
+import type { Command } from "commander";
+import { parseMonthToRange } from "../date-utils.js";
+import { getIncomeReport } from "../../db/repositories/income.js";
+import {
+  isJsonMode,
+  printJson,
+  jsonSuccess,
+  info,
+  createTable,
+  formatCurrency,
+  formatDate,
+} from "../output.js";
+
+export function registerIncomeCommand(program: Command): void {
+  program
+    .command("income [month]")
+    .description("Income breakdown with salary detection (bank accounts only by default)")
+    .option("--salary-only", "Show only salary/wage transactions")
+    .option("--include-refunds", "Also show CC refunds (separate section)")
+    .option("-m, --month-offset <n>", "Months ago (e.g., -m 3 for 3 months ago)", parseInt)
+    .action((month: string | undefined, opts) => {
+      if (opts.monthOffset) month = `-${opts.monthOffset}`;
+      const range = parseMonthToRange(month);
+
+      const result = getIncomeReport({
+        from: range.from,
+        to: range.to,
+        salaryOnly: opts.salaryOnly,
+        includeRefunds: opts.includeRefunds,
+      });
+
+      if (isJsonMode()) {
+        printJson(jsonSuccess({
+          month: range.label,
+          summary: result.summary,
+          transactions: result.transactions,
+        }));
+        return;
+      }
+
+      if (result.transactions.length === 0) {
+        info(`No income data for ${range.label}.`);
+        return;
+      }
+
+      const table = createTable(
+        ["Date", "Description", "Amount", "Type", "Provider"],
+        result.transactions.map((t) => [
+          formatDate(t.date),
+          (t.descriptionEn ?? t.description).length > 35
+            ? (t.descriptionEn ?? t.description).slice(0, 32) + "..."
+            : (t.descriptionEn ?? t.description),
+          formatCurrency(t.chargedAmount),
+          t.incomeType,
+          t.provider,
+        ]),
+      );
+      console.log(table);
+
+      const parts = [`Total: ${formatCurrency(result.summary.totalIncome)}`];
+      if (result.summary.salary > 0) parts.push(`Salary: ${formatCurrency(result.summary.salary)}`);
+      if (result.summary.refunds > 0) parts.push(`Refunds: ${formatCurrency(result.summary.refunds)}`);
+      if (result.summary.other > 0) parts.push(`Other: ${formatCurrency(result.summary.other)}`);
+      info(`\n${range.label} — ${parts.join(" | ")}`);
+    });
+}

--- a/src/cli/commands/insights.ts
+++ b/src/cli/commands/insights.ts
@@ -1,0 +1,113 @@
+// kolshek insights — AI-free financial alerts and recommendations.
+
+import type { Command } from "commander";
+import { subMonths } from "date-fns";
+import chalk from "chalk";
+import {
+  getCategoryByMonth,
+  getLargeTransactions,
+  getMerchantHistory,
+  getMonthCashflow,
+} from "../../db/repositories/insights.js";
+import {
+  detectCategorySpikes,
+  detectLargeTransactions,
+  detectNewMerchants,
+  detectRecurringChanges,
+  detectTrendWarnings,
+  type Insight,
+} from "../../core/insights.js";
+import {
+  isJsonMode,
+  printJson,
+  jsonSuccess,
+  info,
+  getOutputOptions,
+} from "../output.js";
+
+function formatInsight(insight: Insight, noColor: boolean): string {
+  const icon = insight.severity === "alert" ? "[!]" : insight.severity === "warning" ? "[!]" : "[i]";
+  const prefix = noColor
+    ? icon
+    : insight.severity === "alert"
+      ? chalk.red(icon)
+      : insight.severity === "warning"
+        ? chalk.yellow(icon)
+        : chalk.cyan(icon);
+
+  const title = noColor ? insight.title : chalk.bold(insight.title);
+  return `  ${prefix} ${title}\n      ${insight.detail}`;
+}
+
+export function registerInsightsCommand(program: Command): void {
+  program
+    .command("insights")
+    .description("Financial alerts and recommendations based on spending patterns")
+    .option("--months <n>", "Lookback period in months", parseInt, 3)
+    .action((opts) => {
+      const monthCount = opts.months ?? 3;
+      const now = new Date();
+      const from = subMonths(now, monthCount).toISOString().slice(0, 10);
+      const currentMonthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
+
+      const insightOpts = { from, currentMonthStart };
+
+      // Gather all raw data
+      const categoryData = getCategoryByMonth(insightOpts);
+      const currentCategories = categoryData.filter((c) => c.month >= currentMonthStart.slice(0, 7));
+      const priorCategories = categoryData.filter((c) => c.month < currentMonthStart.slice(0, 7));
+
+      const { transactions: largeTxns, avgAmount } = getLargeTransactions(insightOpts);
+      const merchantHistory = getMerchantHistory(insightOpts);
+      const cashflow = getMonthCashflow(insightOpts);
+
+      // Run detectors
+      const insights: Insight[] = [
+        ...detectCategorySpikes(currentCategories, priorCategories),
+        ...detectLargeTransactions(largeTxns, avgAmount),
+        ...detectNewMerchants(merchantHistory),
+        ...detectRecurringChanges(merchantHistory),
+        ...detectTrendWarnings(cashflow),
+      ];
+
+      // Sort by severity
+      const order = { alert: 0, warning: 1, info: 2 };
+      insights.sort((a, b) => order[a.severity] - order[b.severity]);
+
+      if (isJsonMode()) {
+        const summary = {
+          total: insights.length,
+          alerts: insights.filter((i) => i.severity === "alert").length,
+          warnings: insights.filter((i) => i.severity === "warning").length,
+          info: insights.filter((i) => i.severity === "info").length,
+        };
+        printJson(jsonSuccess({ period: { from, months: monthCount }, insights, summary }));
+        return;
+      }
+
+      if (insights.length === 0) {
+        info("No insights to report — spending patterns look normal.");
+        return;
+      }
+
+      const noColor = getOutputOptions().noColor;
+      const alerts = insights.filter((i) => i.severity === "alert");
+      const warnings = insights.filter((i) => i.severity === "warning");
+      const infos = insights.filter((i) => i.severity === "info");
+
+      if (alerts.length > 0) {
+        console.log(noColor ? "\nAlerts:" : chalk.red.bold("\nAlerts:"));
+        for (const i of alerts) console.log(formatInsight(i, noColor));
+      }
+      if (warnings.length > 0) {
+        console.log(noColor ? "\nWarnings:" : chalk.yellow.bold("\nWarnings:"));
+        for (const i of warnings) console.log(formatInsight(i, noColor));
+      }
+      if (infos.length > 0) {
+        console.log(noColor ? "\nInfo:" : chalk.cyan.bold("\nInfo:"));
+        for (const i of infos) console.log(formatInsight(i, noColor));
+      }
+
+      info(`\n${insights.length} insight(s) from the last ${monthCount} month(s).`);
+    });
+}

--- a/src/cli/commands/spending.ts
+++ b/src/cli/commands/spending.ts
@@ -1,0 +1,75 @@
+// kolshek spending — Unified spending view with grouping.
+
+import type { Command } from "commander";
+import { parseMonthToRange } from "../date-utils.js";
+import { getSpendingReport, type SpendingGroupBy } from "../../db/repositories/spending.js";
+import {
+  isJsonMode,
+  printJson,
+  jsonSuccess,
+  printError,
+  info,
+  createTable,
+  formatCurrency,
+  ExitCode,
+} from "../output.js";
+
+const VALID_GROUP_BY = new Set(["category", "merchant", "provider"]);
+
+export function registerSpendingCommand(program: Command): void {
+  program
+    .command("spending [month]")
+    .description("Spending breakdown by category, merchant, or provider")
+    .option("--group-by <field>", "Group by: category (default), merchant, provider", "category")
+    .option("--category <name>", "Filter to a specific category")
+    .option("--top <n>", "Limit to top N groups", parseInt)
+    .option("--type <type>", "Filter by provider type (bank|credit_card)")
+    .option("-m, --month-offset <n>", "Months ago (e.g., -m 3 for 3 months ago)", parseInt)
+    .action((month: string | undefined, opts) => {
+      if (opts.monthOffset) month = `-${opts.monthOffset}`;
+      const groupBy = opts.groupBy as string;
+      if (!VALID_GROUP_BY.has(groupBy)) {
+        printError("BAD_ARGS", `Invalid --group-by value: ${groupBy}. Use: category, merchant, provider`);
+        process.exit(ExitCode.BadArgs);
+      }
+
+      const range = parseMonthToRange(month);
+
+      const result = getSpendingReport({
+        from: range.from,
+        to: range.to,
+        groupBy: groupBy as SpendingGroupBy,
+        category: opts.category,
+        providerType: opts.type,
+        top: opts.top,
+      });
+
+      if (isJsonMode()) {
+        printJson(jsonSuccess({
+          month: range.label,
+          groupBy,
+          summary: result.summary,
+          groups: result.groups,
+        }));
+        return;
+      }
+
+      if (result.groups.length === 0) {
+        info(`No spending data for ${range.label}.`);
+        return;
+      }
+
+      const groupLabel = groupBy.charAt(0).toUpperCase() + groupBy.slice(1);
+      const table = createTable(
+        [groupLabel, "Amount", "Txns", "%"],
+        result.groups.map((g) => [
+          g.label.length > 40 ? g.label.slice(0, 37) + "..." : g.label,
+          formatCurrency(-g.totalAmount),
+          String(g.transactionCount),
+          `${g.percentage}%`,
+        ]),
+      );
+      console.log(table);
+      info(`\n${range.label} — Total: ${formatCurrency(-result.summary.totalExpenses)} | ${result.summary.transactionCount} txns | ${formatCurrency(-result.summary.avgPerDay)}/day`);
+    });
+}

--- a/src/cli/commands/trends.ts
+++ b/src/cli/commands/trends.ts
@@ -1,0 +1,121 @@
+// kolshek trends — Multi-month cashflow and category trend analysis.
+
+import type { Command } from "commander";
+import { subMonths } from "date-fns";
+import {
+  getTotalTrends,
+  getCategoryTrends,
+  getFixedVariableTrends,
+} from "../../db/repositories/trends.js";
+import type { DateRange } from "../../db/repositories/reports.js";
+import {
+  isJsonMode,
+  printJson,
+  jsonSuccess,
+  printError,
+  info,
+  createTable,
+  formatCurrency,
+  ExitCode,
+} from "../output.js";
+
+type TrendMode = "total" | "category" | "fixed-variable";
+const VALID_MODES = new Set<string>(["total", "category", "fixed-variable"]);
+
+function buildMonthRange(months: number): DateRange {
+  const from = subMonths(new Date(), months);
+  return { from: from.toISOString().slice(0, 10) };
+}
+
+export function registerTrendsCommand(program: Command): void {
+  program
+    .command("trends [months]")
+    .description("Multi-month cashflow and spending trend analysis")
+    .option("--mode <mode>", "Analysis mode: total (default), category, fixed-variable", "total")
+    .option("--category <name>", "Track specific category (implies --mode category)")
+    .option("--type <type>", "Filter by provider type (bank|credit_card)")
+    .action((monthsArg: string | undefined, opts) => {
+      const monthCount = monthsArg ? parseInt(monthsArg, 10) : 6;
+      if (isNaN(monthCount) || monthCount < 1) {
+        printError("BAD_ARGS", "months must be a positive number");
+        process.exit(ExitCode.BadArgs);
+      }
+
+      let mode: TrendMode = opts.mode;
+      if (opts.category) mode = "category";
+
+      if (!VALID_MODES.has(mode)) {
+        printError("BAD_ARGS", `Invalid mode: ${mode}. Use: total, category, fixed-variable`);
+        process.exit(ExitCode.BadArgs);
+      }
+
+      if (mode === "category" && !opts.category) {
+        printError("BAD_ARGS", "--category is required for category mode");
+        process.exit(ExitCode.BadArgs);
+      }
+
+      const range = buildMonthRange(monthCount);
+
+      if (mode === "total") {
+        const trends = getTotalTrends(range, opts.type);
+        if (isJsonMode()) {
+          printJson(jsonSuccess({ mode, months: monthCount, trends }));
+          return;
+        }
+        if (trends.length === 0) { info("No data in the selected range."); return; }
+
+        const table = createTable(
+          ["Month", "Income", "Expenses", "Net", "Exp %", "Inc %"],
+          trends.map((t) => [
+            t.month,
+            formatCurrency(t.income),
+            formatCurrency(-(t.bankExpenses + t.ccExpenses)),
+            formatCurrency(t.net),
+            t.expenseChange != null ? `${t.expenseChange > 0 ? "+" : ""}${t.expenseChange}%` : "—",
+            t.incomeChange != null ? `${t.incomeChange > 0 ? "+" : ""}${t.incomeChange}%` : "—",
+          ]),
+        );
+        console.log(table);
+        info(`\n${trends.length} month(s) of trends.`);
+      } else if (mode === "category") {
+        const trends = getCategoryTrends(range, opts.category, opts.type);
+        if (isJsonMode()) {
+          printJson(jsonSuccess({ mode, category: opts.category, months: monthCount, trends }));
+          return;
+        }
+        if (trends.length === 0) { info(`No data for "${opts.category}" in the selected range.`); return; }
+
+        const table = createTable(
+          ["Month", "Amount", "Txns", "Change %"],
+          trends.map((t) => [
+            t.month,
+            formatCurrency(-t.totalAmount),
+            String(t.transactionCount),
+            t.change != null ? `${t.change > 0 ? "+" : ""}${t.change}%` : "—",
+          ]),
+        );
+        console.log(table);
+        info(`\n"${opts.category}" over ${trends.length} month(s).`);
+      } else {
+        const trends = getFixedVariableTrends(range, opts.type);
+        if (isJsonMode()) {
+          printJson(jsonSuccess({ mode, months: monthCount, trends }));
+          return;
+        }
+        if (trends.length === 0) { info("No data in the selected range."); return; }
+
+        const table = createTable(
+          ["Month", "Fixed", "Variable", "Fixed %", "Fixed Merchants"],
+          trends.map((t) => [
+            t.month,
+            formatCurrency(-t.fixed),
+            formatCurrency(-t.variable),
+            `${t.fixedPercent}%`,
+            String(t.fixedMerchants),
+          ]),
+        );
+        console.log(table);
+        info(`\n${trends.length} month(s) — fixed = same merchant, similar amount, 3+ months.`);
+      }
+    });
+}

--- a/src/cli/date-utils.ts
+++ b/src/cli/date-utils.ts
@@ -43,3 +43,44 @@ export function parseDateToDate(input: string): Date | null {
   if (isValid(iso)) return iso;
   return null;
 }
+
+export interface MonthRange {
+  from: string;
+  to: string;
+  label: string;
+}
+
+// Parse month input ("current", "prev", "-3", "2026-03") → date range for that month
+export function parseMonthToRange(input?: string): MonthRange {
+  const now = new Date();
+  let year = now.getFullYear();
+  let month = now.getMonth();
+
+  if (input && input !== "current") {
+    if (input === "prev") {
+      month -= 1;
+    } else if (/^-\d+$/.test(input)) {
+      month -= Number(input.slice(1));
+    } else if (/^\d{4}-\d{2}$/.test(input)) {
+      const parts = input.split("-");
+      year = Number(parts[0]);
+      month = Number(parts[1]) - 1;
+    } else {
+      // Fall back: try parsing as a regular date and use its month
+      const d = parseDateToDate(input);
+      if (d) {
+        year = d.getFullYear();
+        month = d.getMonth();
+      }
+    }
+  }
+
+  const start = new Date(Date.UTC(year, month, 1));
+  const end = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 0));
+
+  return {
+    from: start.toISOString().slice(0, 10),
+    to: end.toISOString().slice(0, 10),
+    label: `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}`,
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,10 @@ import { registerCategorizeCommand } from "./commands/categorize.js";
 import { registerTranslateCommand } from "./commands/translate.js";
 import { registerScheduleCommand } from "./commands/schedule.js";
 import { registerPluginCommand } from "./commands/plugin.js";
+import { registerSpendingCommand } from "./commands/spending.js";
+import { registerIncomeCommand } from "./commands/income.js";
+import { registerTrendsCommand } from "./commands/trends.js";
+import { registerInsightsCommand } from "./commands/insights.js";
 import { getMostRecentSyncTime, listProviders } from "../db/repositories/providers.js";
 import { loadConfig } from "../config/loader.js";
 import { syncProviders } from "../core/sync-engine.js";
@@ -74,7 +78,7 @@ program
       }
 
       // Auto-fetch if data is stale
-      const autoFetchTriggers = new Set(["list", "search", "accounts", "reports", "query", "summary"]);
+      const autoFetchTriggers = new Set(["list", "search", "accounts", "reports", "query", "summary", "spending", "income", "trends", "insights"]);
       if (
         opts.autoFetch !== false &&
         autoFetchTriggers.has(commandName) &&
@@ -129,6 +133,10 @@ registerCategorizeCommand(program);
 registerTranslateCommand(program);
 registerScheduleCommand(program);
 registerPluginCommand(program);
+registerSpendingCommand(program);
+registerIncomeCommand(program);
+registerTrendsCommand(program);
+registerInsightsCommand(program);
 
 // Parse and run
 program.parseAsync(process.argv).then(() => {

--- a/src/core/income.ts
+++ b/src/core/income.ts
@@ -1,0 +1,18 @@
+// Pure income classification logic — no DB or CLI imports.
+
+export type IncomeType = "salary" | "transfer" | "refund" | "other";
+
+const SALARY_PATTERNS = [/salary/i, /wages?/i, /payroll/i, /משכורת/, /שכר\s*עבודה/, /שכר/];
+const REFUND_PATTERNS = [/refund/i, /return/i, /החזר/, /זיכוי/];
+
+export function classifyIncome(
+  description: string,
+  category: string | null,
+  providerType: string,
+): IncomeType {
+  const text = `${description} ${category ?? ""}`;
+  if (providerType === "credit_card") return "refund";
+  if (SALARY_PATTERNS.some((p) => p.test(text))) return "salary";
+  if (REFUND_PATTERNS.some((p) => p.test(text))) return "refund";
+  return "other";
+}

--- a/src/core/insights.ts
+++ b/src/core/insights.ts
@@ -1,0 +1,165 @@
+// Pure insight detection logic — no DB or CLI imports.
+
+export type InsightSeverity = "info" | "warning" | "alert";
+
+export interface Insight {
+  type: string;
+  severity: InsightSeverity;
+  title: string;
+  detail: string;
+  amount?: number;
+}
+
+interface MonthlyCategory {
+  month: string;
+  category: string;
+  total: number;
+}
+
+interface MerchantHistory {
+  merchant: string;
+  monthsSeen: number;
+  currentAmount: number;
+  avgAmount: number;
+  firstSeen: string;
+}
+
+interface MonthCashflow {
+  month: string;
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+interface LargeTransaction {
+  description: string;
+  amount: number;
+  date: string;
+}
+
+// Detect categories with spending spikes (>50% above 3mo avg)
+export function detectCategorySpikes(
+  currentMonth: MonthlyCategory[],
+  priorMonths: MonthlyCategory[],
+): Insight[] {
+  const insights: Insight[] = [];
+
+  const priorAvg = new Map<string, number>();
+  const priorCounts = new Map<string, number>();
+  for (const m of priorMonths) {
+    priorAvg.set(m.category, (priorAvg.get(m.category) ?? 0) + m.total);
+    priorCounts.set(m.category, (priorCounts.get(m.category) ?? 0) + 1);
+  }
+  for (const [cat, total] of priorAvg) {
+    priorAvg.set(cat, total / (priorCounts.get(cat) ?? 1));
+  }
+
+  for (const cur of currentMonth) {
+    const avg = priorAvg.get(cur.category);
+    if (avg && avg > 0 && cur.total > avg * 1.5) {
+      const pctOver = Math.round(((cur.total - avg) / avg) * 100);
+      insights.push({
+        type: "category_spike",
+        severity: pctOver >= 100 ? "alert" : "warning",
+        title: `${cur.category} spending up ${pctOver}%`,
+        detail: `This month: ${cur.total.toFixed(2)} vs avg ${avg.toFixed(2)}`,
+        amount: cur.total - avg,
+      });
+    }
+  }
+
+  return insights;
+}
+
+// Detect unusually large individual transactions
+export function detectLargeTransactions(
+  transactions: LargeTransaction[],
+  avgTransactionSize: number,
+): Insight[] {
+  const threshold = avgTransactionSize * 2;
+  return transactions
+    .filter((t) => t.amount > threshold)
+    .slice(0, 5)
+    .map((t) => ({
+      type: "large_transaction",
+      severity: "info" as InsightSeverity,
+      title: `Large charge: ${t.description}`,
+      detail: `${t.amount.toFixed(2)} on ${t.date} (avg txn: ${avgTransactionSize.toFixed(2)})`,
+      amount: t.amount,
+    }));
+}
+
+// Detect first-time merchants with significant spend
+export function detectNewMerchants(merchants: MerchantHistory[]): Insight[] {
+  return merchants
+    .filter((m) => m.monthsSeen === 1)
+    .sort((a, b) => b.currentAmount - a.currentAmount)
+    .slice(0, 5)
+    .map((m) => ({
+      type: "new_merchant",
+      severity: "info" as InsightSeverity,
+      title: `New: ${m.merchant}`,
+      detail: `First purchase: ${m.currentAmount.toFixed(2)}`,
+      amount: m.currentAmount,
+    }));
+}
+
+// Detect recurring merchants with amount changes (>20%)
+export function detectRecurringChanges(merchants: MerchantHistory[]): Insight[] {
+  return merchants
+    .filter((m) => m.monthsSeen >= 3 && m.avgAmount > 0)
+    .filter((m) => Math.abs(m.currentAmount - m.avgAmount) / m.avgAmount > 0.2)
+    .sort((a, b) => Math.abs(b.currentAmount - b.avgAmount) - Math.abs(a.currentAmount - a.avgAmount))
+    .slice(0, 5)
+    .map((m) => {
+      const pct = Math.round(((m.currentAmount - m.avgAmount) / m.avgAmount) * 100);
+      const dir = pct > 0 ? "up" : "down";
+      return {
+        type: "recurring_change",
+        severity: (Math.abs(pct) >= 50 ? "warning" : "info") as InsightSeverity,
+        title: `${m.merchant} ${dir} ${Math.abs(pct)}%`,
+        detail: `This month: ${m.currentAmount.toFixed(2)} vs avg ${m.avgAmount.toFixed(2)}`,
+        amount: m.currentAmount - m.avgAmount,
+      };
+    });
+}
+
+// Detect cashflow trend warnings
+export function detectTrendWarnings(months: MonthCashflow[]): Insight[] {
+  const insights: Insight[] = [];
+  const chrono = [...months].reverse();
+
+  // 3+ months consecutive expense increase
+  let consecIncreases = 0;
+  for (let i = 1; i < chrono.length; i++) {
+    if (chrono[i].expenses > chrono[i - 1].expenses) {
+      consecIncreases++;
+    } else {
+      consecIncreases = 0;
+    }
+  }
+  if (consecIncreases >= 2) {
+    insights.push({
+      type: "expense_trend",
+      severity: "warning",
+      title: `Expenses rising for ${consecIncreases + 1} months`,
+      detail: "Consider reviewing spending patterns",
+    });
+  }
+
+  // 2+ months negative cashflow
+  let negativeMonths = 0;
+  for (const m of chrono.slice(-3)) {
+    if (m.net < 0) negativeMonths++;
+  }
+  if (negativeMonths >= 2) {
+    insights.push({
+      type: "negative_cashflow",
+      severity: "alert",
+      title: `Negative cashflow for ${negativeMonths} of last 3 months`,
+      detail: "Spending exceeds income — review budget",
+    });
+  }
+
+  return insights;
+}

--- a/src/db/repositories/income.ts
+++ b/src/db/repositories/income.ts
@@ -1,0 +1,118 @@
+// Income queries — bank income + optional CC refunds.
+
+import { getDatabase } from "../database.js";
+import { CC_BILLING_CATEGORY } from "../../types/transaction.js";
+import { classifyIncome, type IncomeType } from "../../core/income.js";
+
+export interface IncomeTransaction {
+  date: string;
+  description: string;
+  descriptionEn: string | null;
+  chargedAmount: number;
+  category: string | null;
+  provider: string;
+  providerType: string;
+  accountNumber: string;
+  incomeType: IncomeType;
+}
+
+export interface IncomeSummary {
+  totalIncome: number;
+  salary: number;
+  transfers: number;
+  refunds: number;
+  other: number;
+  transactionCount: number;
+}
+
+export interface IncomeResult {
+  transactions: IncomeTransaction[];
+  summary: IncomeSummary;
+}
+
+interface IncomeOpts {
+  from: string;
+  to: string;
+  salaryOnly?: boolean;
+  includeRefunds?: boolean;
+}
+
+export function getIncomeReport(opts: IncomeOpts): IncomeResult {
+  const db = getDatabase();
+  const params: Record<string, string | number> = {
+    $from: opts.from,
+    $to: opts.to,
+    $ccBilling: CC_BILLING_CATEGORY,
+  };
+
+  const conditions = [
+    "t.charged_amount > 0",
+    "t.date >= $from",
+    "t.date <= $to",
+    "COALESCE(t.category, '') != $ccBilling",
+  ];
+
+  // Default: bank only. With --include-refunds: all providers
+  if (!opts.includeRefunds) {
+    conditions.push("p.type = 'bank'");
+  }
+
+  const sql = `
+    SELECT
+      t.date, t.description, t.description_en, t.charged_amount, t.category,
+      p.alias AS provider, p.type AS provider_type, a.account_number
+    FROM transactions t
+    JOIN accounts a ON t.account_id = a.id
+    JOIN providers p ON a.provider_id = p.id
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY t.charged_amount DESC
+  `;
+
+  const rows = db.prepare(sql).all(params) as Array<{
+    date: string;
+    description: string;
+    description_en: string | null;
+    charged_amount: number;
+    category: string | null;
+    provider: string;
+    provider_type: string;
+    account_number: string;
+  }>;
+
+  let transactions: IncomeTransaction[] = rows.map((r) => ({
+    date: r.date,
+    description: r.description,
+    descriptionEn: r.description_en,
+    chargedAmount: r.charged_amount,
+    category: r.category,
+    provider: r.provider,
+    providerType: r.provider_type,
+    accountNumber: r.account_number,
+    incomeType: classifyIncome(r.description, r.category, r.provider_type),
+  }));
+
+  if (opts.salaryOnly) {
+    transactions = transactions.filter((t) => t.incomeType === "salary");
+  }
+
+  const summary: IncomeSummary = {
+    totalIncome: 0,
+    salary: 0,
+    transfers: 0,
+    refunds: 0,
+    other: 0,
+    transactionCount: transactions.length,
+  };
+
+  for (const t of transactions) {
+    summary.totalIncome += t.chargedAmount;
+    switch (t.incomeType) {
+      case "salary": summary.salary += t.chargedAmount; break;
+      case "transfer": summary.transfers += t.chargedAmount; break;
+      case "refund": summary.refunds += t.chargedAmount; break;
+      default: summary.other += t.chargedAmount;
+    }
+  }
+
+  return { transactions, summary };
+}

--- a/src/db/repositories/insights.ts
+++ b/src/db/repositories/insights.ts
@@ -1,0 +1,110 @@
+// Raw data queries for insight detectors.
+
+import { getDatabase } from "../database.js";
+import { CC_BILLING_CATEGORY } from "../../types/transaction.js";
+
+interface InsightOpts {
+  from: string;
+  currentMonthStart: string;
+}
+
+export interface CategoryByMonth {
+  month: string;
+  category: string;
+  total: number;
+}
+
+export function getCategoryByMonth(opts: InsightOpts): CategoryByMonth[] {
+  const db = getDatabase();
+  const sql = `
+    SELECT strftime('%Y-%m', t.date) AS month,
+      COALESCE(t.category, 'Uncategorized') AS category,
+      SUM(ABS(t.charged_amount)) AS total
+    FROM transactions t
+    WHERE t.charged_amount < 0 AND t.date >= $from
+      AND COALESCE(t.category, '') != $ccBilling
+    GROUP BY month, category
+    ORDER BY month, total DESC
+  `;
+  return db.prepare(sql).all({ $from: opts.from, $ccBilling: CC_BILLING_CATEGORY }) as CategoryByMonth[];
+}
+
+export interface LargeTransactionRow {
+  description: string;
+  amount: number;
+  date: string;
+}
+
+export function getLargeTransactions(opts: InsightOpts): { transactions: LargeTransactionRow[]; avgAmount: number } {
+  const db = getDatabase();
+
+  const avgRow = db.prepare(`
+    SELECT ROUND(AVG(ABS(charged_amount)), 2) AS avg_amount
+    FROM transactions WHERE charged_amount < 0 AND date >= $from
+      AND COALESCE(category, '') != $ccBilling
+  `).get({ $from: opts.currentMonthStart, $ccBilling: CC_BILLING_CATEGORY }) as { avg_amount: number } | null;
+
+  const avgAmount = avgRow?.avg_amount ?? 0;
+
+  const rows = db.prepare(`
+    SELECT COALESCE(description_en, description) AS description,
+      ABS(charged_amount) AS amount, date
+    FROM transactions WHERE charged_amount < 0 AND date >= $from
+      AND COALESCE(category, '') != $ccBilling
+    ORDER BY amount DESC LIMIT 20
+  `).all({ $from: opts.currentMonthStart, $ccBilling: CC_BILLING_CATEGORY }) as LargeTransactionRow[];
+
+  return { transactions: rows, avgAmount };
+}
+
+export interface MerchantHistoryRow {
+  merchant: string;
+  monthsSeen: number;
+  currentAmount: number;
+  avgAmount: number;
+  firstSeen: string;
+}
+
+export function getMerchantHistory(opts: InsightOpts): MerchantHistoryRow[] {
+  const db = getDatabase();
+  const sql = `
+    SELECT
+      COALESCE(t.description_en, t.description) AS merchant,
+      COUNT(DISTINCT strftime('%Y-%m', t.date)) AS months_seen,
+      SUM(CASE WHEN t.date >= $currentMonth THEN ABS(t.charged_amount) ELSE 0 END) AS current_amount,
+      ROUND(AVG(ABS(t.charged_amount)), 2) AS avg_amount,
+      MIN(t.date) AS first_seen
+    FROM transactions t
+    WHERE t.charged_amount < 0 AND t.date >= $from
+      AND COALESCE(t.category, '') != $ccBilling
+    GROUP BY merchant
+    HAVING current_amount > 0
+    ORDER BY current_amount DESC
+  `;
+  return db.prepare(sql).all({
+    $from: opts.from,
+    $currentMonth: opts.currentMonthStart,
+    $ccBilling: CC_BILLING_CATEGORY,
+  }) as MerchantHistoryRow[];
+}
+
+export interface MonthCashflowRow {
+  month: string;
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+export function getMonthCashflow(opts: InsightOpts): MonthCashflowRow[] {
+  const db = getDatabase();
+  const sql = `
+    SELECT strftime('%Y-%m', date) AS month,
+      SUM(CASE WHEN charged_amount > 0 THEN charged_amount ELSE 0 END) AS income,
+      SUM(CASE WHEN charged_amount < 0 THEN ABS(charged_amount) ELSE 0 END) AS expenses,
+      SUM(CASE WHEN COALESCE(category, '') != $ccBilling THEN charged_amount ELSE 0 END) AS net
+    FROM transactions
+    WHERE date >= $from AND COALESCE(category, '') != $ccBilling
+    GROUP BY month ORDER BY month DESC
+  `;
+  return db.prepare(sql).all({ $from: opts.from, $ccBilling: CC_BILLING_CATEGORY }) as MonthCashflowRow[];
+}

--- a/src/db/repositories/spending.ts
+++ b/src/db/repositories/spending.ts
@@ -1,0 +1,115 @@
+// Spending analysis queries — grouped expense breakdowns by month.
+
+import { getDatabase } from "../database.js";
+import { CC_BILLING_CATEGORY } from "../../types/transaction.js";
+
+export type SpendingGroupBy = "category" | "merchant" | "provider";
+
+export interface SpendingGroup {
+  label: string;
+  totalAmount: number;
+  transactionCount: number;
+  percentage: number;
+}
+
+export interface SpendingSummary {
+  totalExpenses: number;
+  transactionCount: number;
+  avgPerDay: number;
+  daysInRange: number;
+}
+
+export interface SpendingResult {
+  groups: SpendingGroup[];
+  summary: SpendingSummary;
+}
+
+interface SpendingOpts {
+  from: string;
+  to: string;
+  groupBy: SpendingGroupBy;
+  category?: string;
+  providerType?: string;
+  top?: number;
+}
+
+export function getSpendingReport(opts: SpendingOpts): SpendingResult {
+  const db = getDatabase();
+  const params: Record<string, string | number> = {
+    $from: opts.from,
+    $to: opts.to,
+    $ccBilling: CC_BILLING_CATEGORY,
+  };
+
+  const conditions = [
+    "t.charged_amount < 0",
+    "t.date >= $from",
+    "t.date <= $to",
+    "COALESCE(t.category, '') != $ccBilling",
+  ];
+
+  if (opts.category) {
+    conditions.push("COALESCE(t.category, 'Uncategorized') = $category");
+    params.$category = opts.category;
+  }
+  if (opts.providerType) {
+    conditions.push("p.type = $providerType");
+    params.$providerType = opts.providerType;
+  }
+
+  let labelExpr: string;
+  switch (opts.groupBy) {
+    case "merchant":
+      labelExpr = "COALESCE(t.description_en, t.description)";
+      break;
+    case "provider":
+      labelExpr = "p.alias";
+      break;
+    default:
+      labelExpr = "COALESCE(t.category, 'Uncategorized')";
+  }
+
+  const limitClause = opts.top ? `LIMIT ${Number(opts.top)}` : "";
+
+  const sql = `
+    SELECT
+      ${labelExpr} AS label,
+      SUM(ABS(t.charged_amount)) AS total_amount,
+      COUNT(*) AS transaction_count
+    FROM transactions t
+    JOIN accounts a ON t.account_id = a.id
+    JOIN providers p ON a.provider_id = p.id
+    WHERE ${conditions.join(" AND ")}
+    GROUP BY label
+    ORDER BY total_amount DESC
+    ${limitClause}
+  `;
+
+  const rows = db.prepare(sql).all(params) as Array<{
+    label: string;
+    total_amount: number;
+    transaction_count: number;
+  }>;
+
+  const totalExpenses = rows.reduce((s, r) => s + r.total_amount, 0);
+  const totalTxns = rows.reduce((s, r) => s + r.transaction_count, 0);
+
+  const fromDate = new Date(opts.from);
+  const toDate = new Date(opts.to);
+  const daysInRange = Math.max(1, Math.ceil((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24)) + 1);
+
+  return {
+    groups: rows.map((r) => ({
+      label: r.label,
+      totalAmount: r.total_amount,
+      transactionCount: r.transaction_count,
+      percentage: totalExpenses > 0 ? Math.round((r.total_amount / totalExpenses) * 10000) / 100 : 0,
+    })),
+    summary: {
+      totalExpenses,
+      transactionCount: totalTxns,
+      avgPerDay: Math.round((totalExpenses / daysInRange) * 100) / 100,
+      daysInRange,
+    },
+  };
+}

--- a/src/db/repositories/trends.ts
+++ b/src/db/repositories/trends.ts
@@ -1,0 +1,180 @@
+// Trends queries — multi-month cashflow analysis.
+
+import { getDatabase } from "../database.js";
+import { CC_BILLING_CATEGORY } from "../../types/transaction.js";
+import { getMonthlyReport, type MonthlyRow, type DateRange } from "./reports.js";
+
+// --- Total mode ---
+
+export interface TrendTotal extends MonthlyRow {
+  expenseChange: number | null;
+  incomeChange: number | null;
+}
+
+export function getTotalTrends(range: DateRange, providerType?: string): TrendTotal[] {
+  const months = getMonthlyReport(range, providerType);
+  // months come DESC — reverse for chronological MoM calc, then reverse back
+  const chrono = [...months].reverse();
+
+  return chrono.map((m, i): TrendTotal => {
+    const prev = i > 0 ? chrono[i - 1] : null;
+    const totalExpenses = m.bankExpenses + m.ccExpenses;
+    const prevExpenses = prev ? prev.bankExpenses + prev.ccExpenses : null;
+
+    return {
+      ...m,
+      expenseChange: prevExpenses != null && prevExpenses > 0
+        ? Math.round(((totalExpenses - prevExpenses) / prevExpenses) * 10000) / 100
+        : null,
+      incomeChange: prev != null && prev.income > 0
+        ? Math.round(((m.income - prev.income) / prev.income) * 10000) / 100
+        : null,
+    };
+  }).reverse();
+}
+
+// --- Category mode ---
+
+export interface CategoryTrend {
+  month: string;
+  totalAmount: number;
+  transactionCount: number;
+  change: number | null;
+}
+
+export function getCategoryTrends(
+  range: DateRange,
+  category: string,
+  providerType?: string,
+): CategoryTrend[] {
+  const db = getDatabase();
+  const params: Record<string, string | number> = {
+    $ccBilling: CC_BILLING_CATEGORY,
+    $category: category,
+  };
+  const conditions = [
+    "t.charged_amount < 0",
+    "COALESCE(t.category, '') != $ccBilling",
+    "COALESCE(t.category, 'Uncategorized') = $category",
+  ];
+
+  if (range.from) { conditions.push("t.date >= $from"); params.$from = range.from; }
+  if (range.to) { conditions.push("t.date <= $to"); params.$to = range.to; }
+  if (providerType) { conditions.push("p.type = $providerType"); params.$providerType = providerType; }
+
+  const sql = `
+    SELECT strftime('%Y-%m', t.date) AS month,
+      SUM(ABS(t.charged_amount)) AS total_amount,
+      COUNT(*) AS transaction_count
+    FROM transactions t
+    JOIN accounts a ON t.account_id = a.id
+    JOIN providers p ON a.provider_id = p.id
+    WHERE ${conditions.join(" AND ")}
+    GROUP BY month
+    ORDER BY month DESC
+  `;
+
+  const rows = db.prepare(sql).all(params) as Array<{
+    month: string;
+    total_amount: number;
+    transaction_count: number;
+  }>;
+
+  const chrono = [...rows].reverse();
+  return chrono.map((r, i): CategoryTrend => {
+    const prev = i > 0 ? chrono[i - 1] : null;
+    return {
+      month: r.month,
+      totalAmount: r.total_amount,
+      transactionCount: r.transaction_count,
+      change: prev && prev.total_amount > 0
+        ? Math.round(((r.total_amount - prev.total_amount) / prev.total_amount) * 10000) / 100
+        : null,
+    };
+  }).reverse();
+}
+
+// --- Fixed vs Variable mode ---
+
+export interface FixedVariableMonth {
+  month: string;
+  fixed: number;
+  variable: number;
+  fixedPercent: number;
+  fixedMerchants: number;
+}
+
+export function getFixedVariableTrends(range: DateRange, providerType?: string): FixedVariableMonth[] {
+  const db = getDatabase();
+  const params: Record<string, string | number> = { $ccBilling: CC_BILLING_CATEGORY };
+  const conditions = [
+    "t.charged_amount < 0",
+    "COALESCE(t.category, '') != $ccBilling",
+  ];
+
+  if (range.from) { conditions.push("t.date >= $from"); params.$from = range.from; }
+  if (range.to) { conditions.push("t.date <= $to"); params.$to = range.to; }
+  if (providerType) { conditions.push("p.type = $providerType"); params.$providerType = providerType; }
+
+  // Get spending per merchant per month
+  const sql = `
+    SELECT
+      strftime('%Y-%m', t.date) AS month,
+      COALESCE(t.description_en, t.description) AS merchant,
+      SUM(ABS(t.charged_amount)) AS total_amount
+    FROM transactions t
+    JOIN accounts a ON t.account_id = a.id
+    JOIN providers p ON a.provider_id = p.id
+    WHERE ${conditions.join(" AND ")}
+    GROUP BY month, merchant
+    ORDER BY month, merchant
+  `;
+
+  const rows = db.prepare(sql).all(params) as Array<{
+    month: string;
+    merchant: string;
+    total_amount: number;
+  }>;
+
+  // Find "fixed" merchants: appear in 3+ months
+  const merchantMonths = new Map<string, Map<string, number>>();
+  for (const r of rows) {
+    if (!merchantMonths.has(r.merchant)) merchantMonths.set(r.merchant, new Map());
+    merchantMonths.get(r.merchant)!.set(r.month, r.total_amount);
+  }
+
+  const fixedMerchants = new Set<string>();
+  for (const [merchant, months] of merchantMonths) {
+    if (months.size >= 3) {
+      const amounts = [...months.values()];
+      const avg = amounts.reduce((s, a) => s + a, 0) / amounts.length;
+      const maxDev = Math.max(...amounts.map((a) => Math.abs(a - avg) / avg));
+      if (maxDev <= 0.2) fixedMerchants.add(merchant);
+    }
+  }
+
+  // Aggregate by month
+  const monthMap = new Map<string, { fixed: number; variable: number; fixedCount: number }>();
+  for (const r of rows) {
+    if (!monthMap.has(r.month)) monthMap.set(r.month, { fixed: 0, variable: 0, fixedCount: 0 });
+    const entry = monthMap.get(r.month)!;
+    if (fixedMerchants.has(r.merchant)) {
+      entry.fixed += r.total_amount;
+      entry.fixedCount += 1;
+    } else {
+      entry.variable += r.total_amount;
+    }
+  }
+
+  return [...monthMap.entries()]
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([month, d]) => ({
+      month,
+      fixed: Math.round(d.fixed * 100) / 100,
+      variable: Math.round(d.variable * 100) / 100,
+      fixedPercent: d.fixed + d.variable > 0
+        ? Math.round((d.fixed / (d.fixed + d.variable)) * 10000) / 100
+        : 0,
+      fixedMerchants: d.fixedCount,
+    }));
+}


### PR DESCRIPTION
## Summary
- Add 4 new analysis commands: `spending`, `income`, `trends`, `insights`
- `spending [month]` — breakdown by category/merchant/provider with `--group-by`, `--top`, `--category` filters
- `income [month]` — bank-only by default (CC positives are refunds), `--salary-only` and `--include-refunds` options
- `trends [months]` — multi-month trends with 3 modes: total cashflow, single category tracking, fixed-vs-variable expense classification
- `insights` — automated anomaly detection: category spikes, large transactions, new merchants, recurring changes, trend warnings
- Core layer stays pure (`src/core/income.ts`, `src/core/insights.ts` have zero DB/CLI imports)
- Updated CONTEXT.md with new commands, direct SQL section, skill startup checks, CC Billing docs
- Enhanced finance-assistant agent with command decision tree and SQL examples
- Improved categorize/translate skills with shared startup checks
- Regenerated all 8 integration targets (Cursor, Windsurf, Aider, Antigravity, Gemini CLI, OpenCode)

## Test plan
- [ ] `bun run dev -- spending` — verify table output with category grouping
- [ ] `bun run dev -- spending --json` — verify JSON envelope format
- [ ] `bun run dev -- spending --group-by merchant --top 5` — merchant grouping
- [ ] `bun run dev -- income` — bank-only income list with salary detection
- [ ] `bun run dev -- income --salary-only` — filters to salary transactions
- [ ] `bun run dev -- income --include-refunds` — shows CC refunds separately
- [ ] `bun run dev -- trends 6` — 6-month cashflow table with MoM %
- [ ] `bun run dev -- trends --mode category --category Groceries` — single category
- [ ] `bun run dev -- trends --mode fixed-variable` — fixed vs variable breakdown
- [ ] `bun run dev -- insights` — styled insight list with severity colors
- [ ] `bun run dev -- insights --json` — JSON insights envelope
- [ ] `bun run typecheck` — zero TS errors
- [ ] `bun test` — 176/176 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)