### PR TITLE
feat(web): settings dashboard with custom design system

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,0 +1,126 @@
+# KolShek Design System
+
+Source of truth for the settings dashboard CSS. Built with **Tailwind CSS v4** + custom component classes in `src/web/styles.css`.
+
+## Visual Direction
+
+**"Warm precision."** Clean density inspired by Stripe/Linear. Color is an event, not decoration.
+
+- **Indigo primary** (`#6366f1` / `#4f46e5`) with zinc neutrals
+- Monochrome surfaces with selective accent pops
+- Tight vertical rhythm, typographic hierarchy carries meaning
+- Subtle depth via layered shadows with faint indigo tint
+- Transitions: 150ms for micro-interactions, 200-250ms for layout shifts
+
+## Build Pipeline
+
+```bash
+# One-time build
+bun run build:css
+
+# Watch mode during development
+bun run dev:css
+```
+
+Source: `src/web/styles.css` → Output: `src/web/dist/styles.css` (minified via `@tailwindcss/cli`)
+
+## Color Palette
+
+| Token        | Light          | Dark           | Usage                    |
+|-------------|----------------|----------------|--------------------------|
+| Primary     | `#4f46e5`      | `#818cf8`      | Buttons, links, accents  |
+| Primary-alt | `#6366f1`      | `#a5b4fc`      | Gradients, badges, focus |
+| Surface     | `#ffffff`      | `#18181b`      | Cards, inputs            |
+| Background  | warm gradient  | `#09090b` + glow | Body background       |
+| Border      | `#e4e4e7`      | `#27272a`      | Cards, inputs, dividers  |
+| Text        | `#18181b`      | `#e4e4e7`      | Body text                |
+| Text-muted  | `#71717a`      | `#a1a1aa`      | Secondary text (WCAG AA) |
+| Success     | `#059669`      | `#6ee7b7`      | Emerald badges, dots     |
+| Danger      | `#e11d48`      | `#fb7185`      | Rose badges, errors      |
+| Warning     | `#b45309`      | `#fbbf24`      | Amber badges, alerts     |
+
+## Dark Mode
+
+Class-based: `<html class="dark">`. Toggle via `localStorage('kolshek-theme')`.
+
+Contrast hierarchy (on zinc-950 `#09090b`):
+- **Headings**: white `#ffffff` (21:1)
+- **Body**: zinc-100 `#f4f4f5` (18.5:1)
+- **Secondary**: zinc-300 `#d4d4d8` (13:1)
+- **Metadata**: zinc-400 `#a1a1aa` (6.3:1) — minimum for WCAG AA
+
+Never use `dark:text-zinc-500` for readable text (3.7:1 fails AA).
+
+## Component Classes
+
+### Layout
+- `.ks-body` — full-height body with gradient background
+- `.ks-header` — sticky frosted-glass header (`backdrop-filter: blur(16px)`)
+- `.ks-brand` / `.ks-brand-mark` / `.ks-brand-text` — gradient brand lockup with shekel icon
+- `.nav-pill` / `.nav-pill--active` — capsule nav links
+- `.nav-badge` — gradient count pill with glow
+- `.ks-theme-toggle` — SVG sun/moon toggle button
+
+### Buttons
+- `.btn-primary` — indigo gradient with inner highlight, hover lift
+- `.btn-outline` — bordered neutral button
+- `.btn-ghost` — minimal text button, indigo hover
+- `.btn-ghost-danger` — destructive ghost variant (rose)
+- `.btn-sm` — compact size modifier
+
+### Cards
+- `.card` — white surface with layered shadow + indigo tint
+- `.card-header` — subtle gradient header strip
+- `.card-accent` — left-border accent variant
+
+### Badges
+- `.badge-indigo` / `.badge-emerald` / `.badge-rose` / `.badge-amber` / `.badge-zinc`
+- All use semi-transparent backgrounds with matching borders
+
+### Status Dots
+- `.status-dot` + `-success` / `-error` / `-warning` / `-info` / `-neutral`
+- `.status-dot-pulse` — breathing animation
+- `.status-dot-lg` — 10px variant
+
+### Animations
+- `toastSlideIn` / `toastFadeOut` — toast notifications
+- `txFadeOut` — transaction row removal
+- `translateFade` — translation success fade
+- `highlightRow` — indigo flash for new items
+- `statusPulse` — breathing status dot
+
+## Typography
+
+Font: **Inter** (400, 500, 600, 700) via Google Fonts.
+
+| Level          | Size     | Weight | Color (light / dark)         |
+|---------------|----------|--------|------------------------------|
+| Page heading  | text-xl  | 700    | zinc-900 / white             |
+| Section title | text-sm  | 600    | zinc-800 / zinc-100          |
+| Body          | text-sm  | 400    | zinc-700 / zinc-300          |
+| Badge/meta    | text-xs  | 500    | varies by badge color        |
+
+## Icons
+
+All icons are inline SVG (16x16, stroke-based, Feather-style). No icon library dependency.
+
+Key patterns:
+- Section headers: colored icon box (`w-7 h-7 rounded-lg bg-{color}-100`)
+- Buttons: 16px SVG inline with text
+- Empty states: larger icon in rounded container
+- Theme toggle: sun/moon SVGs with `display` toggling
+
+## Tailwind v4 Config
+
+```css
+@import "tailwindcss";
+@source "./**/*.ts";
+@variant dark (&:where(.dark, .dark *));
+@theme {
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+```
+
+No `tailwind.config.js` needed — Tailwind v4 uses CSS-first configuration.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "build:css": "bunx @tailwindcss/cli -i src/web/styles.css -o src/web/dist/styles.css --minify",
+    "dev:css": "bunx @tailwindcss/cli -i src/web/styles.css -o src/web/dist/styles.css --watch",
     "prebuild": "bun scripts/generate-plugin-embed.ts",
     "build": "bun build ./src/cli/index.ts --compile --outfile dist/kolshek",
     "build:windows-x64": "bun build ./src/cli/index.ts --compile --target=bun-windows-x64 --outfile dist/kolshek-windows-x64.exe",
@@ -44,9 +46,11 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@tailwindcss/cli": "^4.2.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/bun": "latest",
     "better-sqlite3": "^12.6.2",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -1,0 +1,42 @@
+// kolshek dashboard — starts a local settings dashboard web server.
+
+import type { Command } from "commander";
+import { startDashboard } from "../../web/server.js";
+import { info, success } from "../output.js";
+
+export function registerDashboardCommand(program: Command): void {
+  program
+    .command("dashboard")
+    .description("Open the settings dashboard in your browser")
+    .option("-p, --port <port>", "Port to listen on", "3000")
+    .option("--no-open", "Don't auto-open the browser")
+    .action(async (opts: { port: string; open: boolean }) => {
+      const port = Number(opts.port);
+
+      const server = startDashboard(port);
+      const url = `http://localhost:${server.port}`;
+
+      success(`Dashboard running at ${url}`);
+      info("Press Ctrl+C to stop.\n");
+
+      if (opts.open) {
+        // Open browser — platform-specific
+        try {
+          const platform = process.platform;
+          if (platform === "win32") {
+            Bun.spawn(["cmd", "/c", "start", url]);
+          } else if (platform === "darwin") {
+            Bun.spawn(["open", url]);
+          } else {
+            Bun.spawn(["xdg-open", url]);
+          }
+        } catch {
+          // Silently ignore if browser open fails
+        }
+      }
+
+      // Keep process alive — Bun.serve() runs in the background
+      // but commander will try to exit. Block with a never-resolving promise.
+      await new Promise(() => {});
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ import { registerSpendingCommand } from "./commands/spending.js";
 import { registerIncomeCommand } from "./commands/income.js";
 import { registerTrendsCommand } from "./commands/trends.js";
 import { registerInsightsCommand } from "./commands/insights.js";
+import { registerDashboardCommand } from "./commands/dashboard.js";
 import { getMostRecentSyncTime, listProviders } from "../db/repositories/providers.js";
 import { loadConfig } from "../config/loader.js";
 import { syncProviders } from "../core/sync-engine.js";
@@ -137,6 +138,7 @@ registerSpendingCommand(program);
 registerIncomeCommand(program);
 registerTrendsCommand(program);
 registerInsightsCommand(program);
+registerDashboardCommand(program);
 
 // Parse and run
 program.parseAsync(process.argv).then(() => {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -257,6 +257,17 @@ CREATE TABLE IF NOT EXISTS spending_excludes (
   category TEXT PRIMARY KEY,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );`],
+
+  ["011_categories.sql", `-- First-class categories table so users can pre-create category names.
+CREATE TABLE IF NOT EXISTS categories (
+  name TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+-- Seed from existing transaction and rule data
+INSERT OR IGNORE INTO categories (name)
+  SELECT COALESCE(category, 'Uncategorized') FROM transactions
+  UNION
+  SELECT category FROM category_rules;`],
 ];
 
 // Run all pending SQL migrations.

--- a/src/db/repositories/categories.ts
+++ b/src/db/repositories/categories.ts
@@ -50,7 +50,47 @@ function escapeLike(s: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// CRUD
+// Category entity CRUD (categories table)
+// ---------------------------------------------------------------------------
+
+export function createCategory(name: string): boolean {
+  const db = getDatabase();
+  const result = db
+    .prepare("INSERT OR IGNORE INTO categories (name) VALUES ($name)")
+    .run({ $name: name });
+  return result.changes > 0;
+}
+
+export function categoryExists(name: string): boolean {
+  const db = getDatabase();
+  const row = db
+    .prepare("SELECT 1 FROM categories WHERE name = $name")
+    .get({ $name: name });
+  return !!row;
+}
+
+export function deleteCategory(
+  name: string,
+  moveTo: string,
+): { transactionsUpdated: number; rulesUpdated: number } {
+  const result = renameCategory(name, moveTo);
+  const db = getDatabase();
+  db.prepare("DELETE FROM categories WHERE name = $name").run({ $name: name });
+  // Ensure destination exists
+  db.prepare("INSERT OR IGNORE INTO categories (name) VALUES ($name)").run({ $name: moveTo });
+  return result;
+}
+
+export function listAllCategories(): string[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare("SELECT name FROM categories ORDER BY name")
+    .all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+// ---------------------------------------------------------------------------
+// Rule CRUD
 // ---------------------------------------------------------------------------
 
 export function addCategoryRule(
@@ -289,6 +329,10 @@ export function renameCategory(oldName: string, newName: string): RenameResult {
       .prepare("UPDATE category_rules SET category = $new WHERE category = $old")
       .run({ $old: oldName, $new: newName });
 
+    // Update categories table: ensure new exists, remove old
+    db.prepare("INSERT OR IGNORE INTO categories (name) VALUES ($name)").run({ $name: newName });
+    db.prepare("DELETE FROM categories WHERE name = $name").run({ $name: oldName });
+
     db.run("COMMIT");
     return {
       transactionsUpdated: txResult.changes,
@@ -469,6 +513,8 @@ export function listCategoriesWithSource(): CategoryWithSource[] {
          SELECT COALESCE(category, 'Uncategorized') AS category FROM transactions
          UNION
          SELECT category FROM category_rules
+         UNION
+         SELECT name AS category FROM categories
        ) cat
        LEFT JOIN (
          SELECT COALESCE(category, 'Uncategorized') AS category,

--- a/src/db/repositories/transactions.ts
+++ b/src/db/repositories/transactions.ts
@@ -294,6 +294,19 @@ function buildFilterClauses(filters: TransactionFilters): {
     conditions.push("t.description LIKE $description ESCAPE '\\'");
     params.$description = `%${escapeLike(filters.description)}%`;
   }
+  if (filters.category !== undefined) {
+    if (filters.category === null || filters.category === "Uncategorized") {
+      conditions.push("(t.category IS NULL OR t.category = 'Uncategorized')");
+    } else {
+      conditions.push("t.category = $category");
+      params.$category = filters.category;
+    }
+  }
+  if (filters.translated === true) {
+    conditions.push("t.description_en IS NOT NULL");
+  } else if (filters.translated === false) {
+    conditions.push("t.description_en IS NULL");
+  }
 
   return { conditions, params };
 }
@@ -388,6 +401,32 @@ export function deleteTransaction(
       date: existing.date,
     },
   };
+}
+
+export function updateTransactionCategory(
+  id: number,
+  category: string,
+): boolean {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      "UPDATE transactions SET category = $category, updated_at = datetime('now') WHERE id = $id",
+    )
+    .run({ $id: id, $category: category });
+  return result.changes > 0;
+}
+
+export function updateTransactionTranslation(
+  id: number,
+  descriptionEn: string,
+): boolean {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      "UPDATE transactions SET description_en = $descriptionEn, updated_at = datetime('now') WHERE id = $id",
+    )
+    .run({ $id: id, $descriptionEn: descriptionEn });
+  return result.changes > 0;
 }
 
 export function countTransactions(filters?: TransactionFilters): number {

--- a/src/db/repositories/translations.ts
+++ b/src/db/repositories/translations.ts
@@ -90,6 +90,88 @@ export function applyTranslationRules(): { applied: number } {
   return { applied };
 }
 
+export interface UntranslatedGroup {
+  description: string;
+  count: number;
+  totalAmount: number;
+}
+
+export function listUntranslatedGrouped(): UntranslatedGroup[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT description, COUNT(*) AS count, SUM(ABS(charged_amount)) AS total_amount
+       FROM transactions
+       WHERE description_en IS NULL
+       GROUP BY description
+       ORDER BY count DESC, total_amount DESC`,
+    )
+    .all() as Array<{ description: string; count: number; total_amount: number }>;
+
+  return rows.map((r) => ({
+    description: r.description,
+    count: r.count,
+    totalAmount: r.total_amount,
+  }));
+}
+
+// Translate all transactions matching a Hebrew description
+export function translateByDescription(
+  hebrewDesc: string,
+  englishName: string,
+): number {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      `UPDATE transactions SET description_en = $en, updated_at = datetime('now')
+       WHERE description = $desc AND description_en IS NULL`,
+    )
+    .run({ $en: englishName, $desc: hebrewDesc });
+  return result.changes;
+}
+
+export interface TranslatedGroup {
+  description: string;
+  descriptionEn: string;
+  count: number;
+  totalAmount: number;
+}
+
+export function listTranslatedGrouped(): TranslatedGroup[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT description, description_en, COUNT(*) AS count, SUM(ABS(charged_amount)) AS total_amount
+       FROM transactions
+       WHERE description_en IS NOT NULL
+       GROUP BY description, description_en
+       ORDER BY count DESC, total_amount DESC`,
+    )
+    .all() as Array<{ description: string; description_en: string; count: number; total_amount: number }>;
+
+  return rows.map((r) => ({
+    description: r.description,
+    descriptionEn: r.description_en,
+    count: r.count,
+    totalAmount: r.total_amount,
+  }));
+}
+
+// Update translation for all transactions matching a Hebrew description (overwrites existing)
+export function updateTranslationByDescription(
+  hebrewDesc: string,
+  englishName: string,
+): number {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      `UPDATE transactions SET description_en = $en, updated_at = datetime('now')
+       WHERE description = $desc`,
+    )
+    .run({ $en: englishName, $desc: hebrewDesc });
+  return result.changes;
+}
+
 export interface TranslationRuleInput {
   englishName: string;
   matchPattern: string;

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -75,6 +75,8 @@ export interface TransactionFilters {
   maxAmount?: number;
   status?: TransactionStatus;
   description?: string;
+  category?: string | null;
+  translated?: boolean;
   sort?: "date" | "amount";
   sortDirection?: "asc" | "desc";
   limit?: number;

--- a/src/web/layout.ts
+++ b/src/web/layout.ts
@@ -1,6 +1,6 @@
 // HTML layout shell for the settings dashboard.
-// Pico CSS (classless) + HTMX loaded from CDN. Zero build step.
-// Custom teal/warm-gray design system with dark mode support.
+// Tailwind CSS (built via @tailwindcss/cli) + HTMX.
+// KolShek design system: indigo primary, zinc neutrals, Inter font.
 
 import { listProviders } from "../db/repositories/providers.js";
 import { listCategories } from "../db/repositories/categories.js";
@@ -12,6 +12,11 @@ interface NavCounts {
   untranslated?: number;
 }
 
+// Inline SVG icons for the theme toggle (16x16, stroke-based)
+const sunIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="theme-icon-sun"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>`;
+
+const moonIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="theme-icon-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
+
 export function layout(title: string, currentPath: string, body: string, counts?: NavCounts): string {
   // Auto-query counts if not provided
   const c = counts ?? {
@@ -20,8 +25,15 @@ export function layout(title: string, currentPath: string, body: string, counts?
     untranslated: listUntranslatedGrouped().length,
   };
 
-  const navBadge = (n: number | undefined) =>
-    n != null && n > 0 ? ` <span class="nav-count">${n}</span>` : "";
+  const navLink = (href: string, label: string, count?: number) => {
+    const isActive = currentPath === href;
+    const base = "nav-pill";
+    const active = isActive ? "nav-pill--active" : "";
+    const badge = count != null && count > 0
+      ? ` <span class="nav-badge">${count}</span>`
+      : "";
+    return `<a href="${href}" class="${base} ${active}"${isActive ? ' aria-current="page"' : ""}>${label}${badge}</a>`;
+  };
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -32,661 +44,64 @@ export function layout(title: string, currentPath: string, body: string, counts?
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-  <style>
-    /* ── Typography ── */
-    :root, [data-theme="light"], [data-theme="dark"] {
-      --pico-font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      --pico-font-size: 15px;
-      --pico-line-height: 1.5;
-    }
-
-    /* ── Light theme (default) ── */
-    :root {
-      --pico-primary: #0d9488;
-      --pico-primary-background: #0d9488;
-      --pico-primary-hover: #0f766e;
-      --pico-primary-hover-background: #0f766e;
-      --pico-primary-focus: rgba(13, 148, 136, 0.125);
-      --pico-primary-inverse: #fff;
-      --pico-background-color: #f8fafc;
-      --pico-card-background-color: #ffffff;
-      --pico-card-sectioning-background-color: #f8fafc;
-      --pico-muted-color: #64748b;
-      --pico-muted-border-color: #e2e8f0;
-      --pico-form-element-border-color: #cbd5e1;
-      --pico-form-element-focus-color: var(--pico-primary);
-      --accent-gold: #d97706;
-      --surface: #ffffff;
-      --surface-hover: #f1f5f9;
-      --card-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-      --card-shadow-hover: 0 4px 12px rgba(0,0,0,0.08);
-      --badge-success-bg: #dcfce7;
-      --badge-success-fg: #166534;
-      --badge-danger-bg: #fef2f2;
-      --badge-danger-fg: #991b1b;
-      --badge-warning-bg: #fffbeb;
-      --badge-warning-fg: #92400e;
-      --condition-bg: #f0fdfa;
-      --condition-fg: #115e59;
-      --condition-border: #99f6e4;
-      --toast-shadow: 0 8px 24px rgba(0,0,0,0.12);
-      --empty-icon-color: #94a3b8;
-      --nav-bg: #ffffff;
-      --nav-border: #e2e8f0;
-      --nav-shadow: 0 1px 3px rgba(0,0,0,0.04);
-    }
-
-    /* ── Dark theme ── */
-    [data-theme="dark"] {
-      --pico-primary: #2dd4bf;
-      --pico-primary-background: #0d9488;
-      --pico-primary-hover: #14b8a6;
-      --pico-primary-hover-background: #14b8a6;
-      --pico-primary-focus: rgba(45, 212, 191, 0.15);
-      --pico-primary-inverse: #042f2e;
-      --pico-background-color: #0c0f1a;
-      --pico-card-background-color: #141726;
-      --pico-card-sectioning-background-color: #111425;
-      --pico-color: #e2e8f0;
-      --pico-h1-color: #f1f5f9;
-      --pico-h2-color: #f1f5f9;
-      --pico-h3-color: #e2e8f0;
-      --pico-muted-color: #94a3b8;
-      --pico-muted-border-color: #1e293b;
-      --pico-form-element-background-color: #0f172a;
-      --pico-form-element-border-color: #334155;
-      --pico-form-element-focus-color: var(--pico-primary);
-      --surface: #141726;
-      --surface-hover: #1e2235;
-      --card-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
-      --card-shadow-hover: 0 4px 12px rgba(0,0,0,0.4);
-      --badge-success-bg: rgba(34, 197, 94, 0.15);
-      --badge-success-fg: #86efac;
-      --badge-danger-bg: rgba(239, 68, 68, 0.15);
-      --badge-danger-fg: #fca5a5;
-      --badge-warning-bg: rgba(245, 158, 11, 0.15);
-      --badge-warning-fg: #fcd34d;
-      --condition-bg: rgba(45, 212, 191, 0.1);
-      --condition-fg: #5eead4;
-      --condition-border: rgba(45, 212, 191, 0.2);
-      --toast-shadow: 0 8px 24px rgba(0,0,0,0.4);
-      --empty-icon-color: #475569;
-      --nav-bg: #111425;
-      --nav-border: #1e293b;
-      --nav-shadow: 0 1px 3px rgba(0,0,0,0.3);
-    }
-
-    /* ── Global transitions ── */
-    html { transition: background-color 0.2s ease; }
-    body { transition: color 0.2s ease; }
-
-    /* ── Nav ── */
-    header.container {
-      background: var(--nav-bg);
-      border-bottom: 1px solid var(--nav-border);
-      box-shadow: var(--nav-shadow);
-      margin-bottom: 2rem;
-      max-width: 100%;
-      padding: 0;
-    }
-    header.container nav {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 0 1.5rem;
-    }
-    header.container nav > ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-    header.container nav > ul:last-child {
-      gap: 0.75rem;
-    }
-    nav a {
-      text-decoration: none;
-      color: var(--pico-muted-color);
-      font-weight: 500;
-      font-size: 0.9rem;
-      padding: 0.75rem 0;
-      transition: color 0.15s;
-    }
-    nav a:hover { color: var(--pico-color, #1e293b); }
-    nav a[aria-current="page"] {
-      color: var(--pico-primary);
-      border-bottom: 2px solid var(--pico-primary);
-      padding-bottom: calc(0.75rem - 2px);
-      text-decoration: none;
-    }
-    nav strong {
-      font-size: 1.05rem;
-      letter-spacing: -0.02em;
-    }
-    .nav-count {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 1.2rem;
-      height: 1.2rem;
-      padding: 0 0.3rem;
-      margin-left: 0.3rem;
-      font-size: 0.65rem;
-      font-weight: 700;
-      border-radius: 9999px;
-      background: var(--pico-primary);
-      color: var(--pico-primary-inverse);
-      vertical-align: middle;
-    }
-    #theme-toggle {
-      background: none;
-      border: 1px solid var(--pico-muted-border-color);
-      border-radius: 0.375rem;
-      padding: 0.35rem 0.55rem;
-      cursor: pointer;
-      font-size: 1.05rem;
-      color: var(--pico-muted-color);
-      transition: color 0.2s, border-color 0.2s, background 0.2s;
-      line-height: 1;
-      margin: 0;
-    }
-    #theme-toggle:hover {
-      color: var(--pico-primary);
-      border-color: var(--pico-primary);
-      background: var(--pico-primary-focus);
-    }
-
-    /* ── Main container ── */
-    main.container { max-width: 1200px; }
-
-    /* ── Page header ── */
-    .page-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 1.5rem;
-    }
-    .page-header hgroup { margin-bottom: 0; }
-    .page-header hgroup h2 { margin-bottom: 0.1rem; font-size: 1.6rem; letter-spacing: -0.02em; }
-    .page-header hgroup p { margin-bottom: 0; }
-
-    /* ── Cards / Articles ── */
-    article {
-      border: 1px solid var(--pico-muted-border-color);
-      border-radius: 0.75rem;
-      background: var(--surface);
-      box-shadow: var(--card-shadow);
-      transition: box-shadow 0.2s;
-      overflow: hidden;
-      margin-bottom: 1.25rem;
-      padding: 0;
-    }
-    article > table,
-    article > details,
-    article > form,
-    article > div,
-    article > header,
-    article > p,
-    article > fieldset {
-      margin: 0;
-    }
-    // Override Pico's default article padding — we want tighter cards
-    article { padding: 1.25rem; }
-    article header {
-      border-bottom: 1px solid var(--pico-muted-border-color);
-      margin: -1.25rem -1.25rem 1rem -1.25rem;
-      padding: 0.85rem 1.25rem;
-      background: var(--pico-card-sectioning-background-color);
-    }
-
-    /* ── Badges (pills) ── */
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      padding: 0.2rem 0.6rem;
-      border-radius: 9999px;
-      font-size: 0.72rem;
-      font-weight: 600;
-      white-space: nowrap;
-      line-height: 1.4;
-      letter-spacing: 0.01em;
-    }
-    .badge-success {
-      background: var(--badge-success-bg);
-      color: var(--badge-success-fg);
-    }
-    .badge-danger {
-      background: var(--badge-danger-bg);
-      color: var(--badge-danger-fg);
-    }
-    .badge-warning {
-      background: var(--badge-warning-bg);
-      color: var(--badge-warning-fg);
-    }
-
-    /* ── Condition tags ── */
-    .condition-tag {
-      display: inline-block;
-      padding: 0.15rem 0.5rem;
-      margin: 0.1rem 0.15rem;
-      font-size: 0.75rem;
-      font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
-      background: var(--condition-bg);
-      color: var(--condition-fg);
-      border: 1px solid var(--condition-border);
-      border-radius: 0.3rem;
-      white-space: nowrap;
-    }
-
-    /* ── Empty states ── */
-    .empty-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 3rem 1rem;
-      text-align: center;
-    }
-    .empty-state .empty-icon {
-      font-size: 2.5rem;
-      color: var(--empty-icon-color);
-      line-height: 1;
-      margin-bottom: 0.25rem;
-    }
-    .empty-state p {
-      margin: 0;
-      max-width: 26rem;
-    }
-    .empty-state .text-muted {
-      font-size: 0.85rem;
-    }
-
-    /* ── Tables ── */
-    table { margin-bottom: 0; }
-    .card-table { width: 100%; }
-    .card-table thead th {
-      font-size: 0.78rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--pico-muted-color);
-      padding: 0.65rem 1rem;
-      border-bottom: 1px solid var(--pico-muted-border-color);
-    }
-    .card-table tbody td {
-      padding: 0.7rem 1rem;
-      font-size: 0.9rem;
-      vertical-align: middle;
-    }
-    .card-table tbody tr {
-      transition: background 0.12s;
-    }
-    .card-table tbody tr:hover {
-      background: var(--surface-hover);
-    }
-    .card-table tbody tr:not(:last-child) td {
-      border-bottom: 1px solid var(--pico-muted-border-color);
-    }
-    .card-table tbody tr:last-child td {
-      border-bottom: none;
-    }
-
-    /* ── Responsive: table → cards at 576px ── */
-    @media (max-width: 576px) {
-      .page-header {
-        flex-direction: column;
-        align-items: stretch;
-      }
-      .page-header button,
-      .page-header a[role="button"] {
-        width: 100%;
-      }
-      .card-table thead { display: none; }
-      .card-table tbody tr {
-        display: block;
-        margin-bottom: 0.75rem;
-        padding: 0.75rem;
-        border: 1px solid var(--pico-muted-border-color);
-        border-radius: 0.5rem;
-        background: var(--surface);
-      }
-      .card-table tbody td {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.3rem 0;
-        border: none !important;
-      }
-      .card-table tbody td::before {
-        content: attr(data-label);
-        font-weight: 600;
-        margin-right: 1rem;
-        flex-shrink: 0;
-        font-size: 0.8rem;
-        color: var(--pico-muted-color);
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-      }
-      .card-table tbody td:empty { display: none; }
-      .card-table tbody td[data-label=""] { justify-content: flex-end; }
-      .card-table tbody td[data-label=""]::before { display: none; }
-    }
-
-    /* ── Actions ── */
-    .actions {
-      display: flex;
-      gap: 0.35rem;
-      justify-content: flex-end;
-    }
-    .actions button {
-      padding: 0.3rem 0.55rem;
-      font-size: 0.82rem;
-      margin: 0;
-      border-radius: 0.375rem;
-      transition: background 0.15s, color 0.15s, border-color 0.15s;
-    }
-
-    /* ── Toasts ── */
-    #toast-container {
-      position: fixed;
-      top: 1rem;
-      right: 1rem;
-      z-index: 999;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      max-width: 22rem;
-    }
-    .toast {
-      position: relative;
-      padding: 0.75rem 1.25rem;
-      border-radius: 0.625rem;
-      color: #fff;
-      box-shadow: var(--toast-shadow);
-      animation: toastSlideIn 0.25s ease-out;
-      line-height: 1.4;
-      font-size: 0.88rem;
-      backdrop-filter: blur(8px);
-    }
-    .toast-success { background: rgba(22, 163, 74, 0.95); }
-    .toast-error {
-      background: rgba(220, 38, 38, 0.95);
-      padding-right: 2.5rem;
-    }
-    .toast-close {
-      position: absolute;
-      top: 0.4rem;
-      right: 0.5rem;
-      background: none;
-      border: none;
-      color: rgba(255,255,255,0.7);
-      font-size: 1.1rem;
-      cursor: pointer;
-      padding: 0.15rem 0.35rem;
-      line-height: 1;
-      margin: 0;
-      border-radius: 0.25rem;
-      transition: color 0.15s;
-    }
-    .toast-close:hover { color: #fff; }
-    .toast.removing {
-      animation: toastFadeOut 0.3s ease-out forwards;
-    }
-    @keyframes toastSlideIn {
-      from { opacity: 0; transform: translateX(1rem); }
-      to   { opacity: 1; transform: translateX(0); }
-    }
-    @keyframes toastFadeOut {
-      from { opacity: 1; transform: translateY(0); }
-      to   { opacity: 0; transform: translateY(-0.5rem); }
-    }
-
-    /* ── Row highlight (newly added) ── */
-    @keyframes highlightRow {
-      from { background: var(--pico-primary-focus); }
-      to   { background: transparent; }
-    }
-    .highlight-new { animation: highlightRow 1.5s ease-out; }
-
-    /* ── Misc ── */
-    .text-muted { color: var(--pico-muted-color); font-size: 0.875rem; }
-    details[open] summary { margin-bottom: 1rem; }
-    details summary[role="button"].outline {
-      width: 100%;
-      text-align: center;
-      border-radius: 0.5rem;
-    }
-    fieldset {
-      border: 1px solid var(--pico-muted-border-color);
-      border-radius: 0.5rem;
-      padding: 1rem;
-    }
-    h2 { letter-spacing: -0.02em; }
-    h3, h4 { letter-spacing: -0.01em; }
-
-    /* ── Button polish ── */
-    button, [role="button"] {
-      border-radius: 0.5rem;
-      font-weight: 500;
-      letter-spacing: -0.01em;
-      transition: all 0.15s ease;
-    }
-    input, select, textarea {
-      border-radius: 0.5rem !important;
-    }
-
-    /* ── Provider cards ── */
-    .provider-card {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      padding: 1rem 1.25rem;
-      border-bottom: 1px solid var(--pico-muted-border-color);
-    }
-    .provider-card:last-child { border-bottom: none; }
-    .provider-card-info { flex: 1; min-width: 0; }
-    .provider-card-name { font-weight: 600; font-size: 0.95rem; }
-    .provider-card-meta { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; font-size: 0.82rem; color: var(--pico-muted-color); margin-top: 0.2rem; }
-    .provider-card-meta .separator { opacity: 0.4; }
-    .provider-card-actions { display: flex; gap: 0.35rem; flex-shrink: 0; }
-    .provider-card-actions button { padding: 0.3rem 0.6rem; font-size: 0.8rem; margin: 0; }
-    .provider-add-card {
-      border: 2px dashed var(--pico-muted-border-color);
-      background: transparent;
-      box-shadow: none;
-      cursor: pointer;
-      text-align: center;
-      transition: border-color 0.15s, background 0.15s;
-    }
-    .provider-add-card:hover {
-      border-color: var(--pico-primary);
-      background: var(--pico-primary-focus);
-    }
-
-    /* ── Categories layout ── */
-    .categories-layout {
-      display: grid;
-      grid-template-columns: minmax(220px, 280px) 1fr;
-      gap: 1.5rem;
-      align-items: start;
-    }
-    .category-sidebar { position: sticky; top: 1rem; }
-    .category-list { list-style: none; padding: 0; margin: 0; }
-    .category-item {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.5rem 0.75rem;
-      border-radius: 0.5rem;
-      border-left: 3px solid transparent;
-      cursor: pointer;
-      transition: background 0.12s, border-color 0.12s;
-      font-size: 0.9rem;
-      text-decoration: none;
-      color: inherit;
-    }
-    .category-item:hover { background: var(--surface-hover); }
-    .category-item.active {
-      background: var(--pico-primary-focus);
-      border-left-color: var(--pico-primary);
-      font-weight: 600;
-    }
-    .category-item.uncategorized { border-left-color: var(--accent-gold); }
-    .category-item .cat-count {
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: var(--pico-muted-color);
-      min-width: 1.5rem;
-      text-align: right;
-    }
-
-    /* ── Transaction rows ── */
-    .tx-row {
-      display: grid;
-      grid-template-columns: 4.5rem 1fr auto auto;
-      gap: 0.75rem;
-      align-items: center;
-      padding: 0.6rem 1rem;
-      border-bottom: 1px solid var(--pico-muted-border-color);
-      transition: background 0.12s;
-    }
-    .tx-row:last-child { border-bottom: none; }
-    .tx-row:hover { background: var(--surface-hover); }
-    .tx-date { font-size: 0.82rem; color: var(--pico-muted-color); white-space: nowrap; }
-    .tx-desc { min-width: 0; overflow: hidden; }
-    .tx-desc-he { direction: rtl; unicode-bidi: isolate; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.9rem; }
-    .tx-desc-en { display: block; font-size: 0.78rem; color: var(--pico-muted-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .tx-amount { font-size: 0.9rem; font-weight: 500; white-space: nowrap; text-align: right; font-variant-numeric: tabular-nums; }
-    .tx-amount-expense { color: var(--badge-danger-fg); }
-    .tx-amount-income { color: var(--badge-success-fg); }
-    .inline-select { margin: 0; padding: 0.25rem 0.5rem; font-size: 0.82rem; height: auto; min-width: 8rem; }
-    .tx-row--moved {
-      background: var(--badge-success-bg);
-      opacity: 0.7;
-      pointer-events: none;
-      animation: txFadeOut 0.6s 0.4s ease-out forwards;
-    }
-    @keyframes txFadeOut {
-      to { opacity: 0; height: 0; padding: 0; border: none; overflow: hidden; }
-    }
-
-    /* ── Category action panel (inline confirm) ── */
-    .category-action-panel {
-      padding: 1rem 1.25rem;
-      background: var(--pico-primary-focus);
-      border-bottom: 1px solid var(--pico-muted-border-color);
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-      font-size: 0.9rem;
-    }
-    .category-action-panel select { margin: 0; min-width: 10rem; }
-    .category-action-panel button { margin: 0; }
-
-    /* ── Translation rows ── */
-    .translate-row {
-      display: grid;
-      grid-template-columns: minmax(120px, 1fr) auto minmax(200px, 1.2fr) auto;
-      gap: 0.75rem;
-      align-items: center;
-      padding: 0.75rem 1rem;
-      border-bottom: 1px solid var(--pico-muted-border-color);
-    }
-    .translate-row:last-child { border-bottom: none; }
-    .translate-source { direction: rtl; unicode-bidi: isolate; text-align: right; font-size: 0.9rem; }
-    .translate-source-meta { font-size: 0.78rem; color: var(--pico-muted-color); direction: ltr; }
-    .translate-arrow { color: var(--pico-muted-color); font-size: 1.1rem; text-align: center; }
-    .translate-input-group { display: flex; gap: 0.5rem; align-items: center; }
-    .translate-input-group input[type="text"] { margin: 0; font-size: 0.88rem; }
-    .translate-input-group label { font-size: 0.78rem; white-space: nowrap; display: flex; align-items: center; gap: 0.25rem; margin: 0; }
-    .translate-input-group label input[type="checkbox"] { margin: 0; width: auto; }
-    .translate-row-success {
-      background: var(--badge-success-bg);
-      color: var(--badge-success-fg);
-      font-size: 0.88rem;
-      animation: translateFade 2s ease-out forwards;
-    }
-    @keyframes translateFade {
-      0%, 70% { opacity: 1; max-height: 4rem; padding: 0.75rem 1rem; }
-      100% { opacity: 0; max-height: 0; padding: 0; overflow: hidden; border: none; }
-    }
-
-    /* ── Mobile: categories layout ── */
-    @media (max-width: 768px) {
-      .categories-layout { grid-template-columns: 1fr; }
-      .category-sidebar { position: sticky; top: 0; z-index: 10; background: var(--pico-background-color); padding: 0.5rem 0; border-bottom: 1px solid var(--pico-muted-border-color); }
-      .category-list { display: flex; overflow-x: auto; gap: 0.35rem; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
-      .category-item { flex-shrink: 0; border-radius: 9999px; border: 1px solid var(--pico-muted-border-color); font-size: 0.82rem; white-space: nowrap; border-left: none; padding: 0.35rem 0.75rem; }
-      .category-item.active { border-color: var(--pico-primary); }
-      .category-item.uncategorized { border-color: var(--accent-gold); }
-      .tx-row { grid-template-columns: 1fr; gap: 0.25rem; }
-      .tx-date { font-size: 0.75rem; }
-      .inline-select { width: 100%; }
-      .translate-row { grid-template-columns: 1fr; }
-      .translate-arrow { display: none; }
-      .provider-card { flex-direction: column; align-items: stretch; gap: 0.75rem; }
-      .provider-card-actions { justify-content: flex-end; }
-    }
-
-    /* ── Reduced motion ── */
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        transition-duration: 0.01ms !important;
-      }
-    }
-  </style>
 </head>
-<body>
-  <header class="container">
-    <nav>
-      <ul>
-        <li><strong>&#9670; KolShek</strong></li>
-      </ul>
-      <ul>
-        <li><a href="/providers"${currentPath === "/providers" ? ' aria-current="page"' : ""}>Providers${navBadge(c.providers)}</a></li>
-        <li><a href="/categories"${currentPath === "/categories" ? ' aria-current="page"' : ""}>Categories${navBadge(c.categories)}</a></li>
-        <li><a href="/translations"${currentPath === "/translations" ? ' aria-current="page"' : ""}>Translations${navBadge(c.untranslated)}</a></li>
-        <li>
-          <button id="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode">
-            <span id="theme-icon"></span>
-          </button>
-        </li>
-      </ul>
+<body class="ks-body">
+  <header class="ks-header">
+    <nav class="max-w-6xl mx-auto px-6 flex items-center justify-between h-14">
+      <a href="/providers" class="ks-brand group">
+        <span class="ks-brand-mark">&#8362;</span>
+        <span class="ks-brand-text">KolShek</span>
+      </a>
+      <div class="flex items-center gap-1.5">
+        ${navLink("/providers", "Providers", c.providers)}
+        ${navLink("/categories", "Categories", c.categories)}
+        ${navLink("/translations", "Translations", c.untranslated)}
+        <button id="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode"
+          class="ks-theme-toggle" aria-label="Toggle dark mode">
+          ${sunIcon}
+          ${moonIcon}
+        </button>
+      </div>
     </nav>
   </header>
-  <main class="container">
+  <main class="max-w-6xl mx-auto px-6 py-8">
     ${body}
   </main>
-  <div id="toast-container" hx-swap-oob="true"></div>
+  <div id="toast-container" class="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-sm" hx-swap-oob="true"></div>
   <script>
-    // ── Dark mode ──
+    // Dark mode — SVG icon swap via display toggling
     (function() {
       var stored = localStorage.getItem('kolshek-theme');
       var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
       var theme = stored || (prefersDark ? 'dark' : 'light');
-      document.documentElement.setAttribute('data-theme', theme);
+      if (theme === 'dark') document.documentElement.classList.add('dark');
       updateThemeIcon(theme);
     })();
 
     function toggleTheme() {
-      var current = document.documentElement.getAttribute('data-theme') || 'light';
-      var next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('kolshek-theme', next);
-      updateThemeIcon(next);
+      var isDark = document.documentElement.classList.toggle('dark');
+      var theme = isDark ? 'dark' : 'light';
+      localStorage.setItem('kolshek-theme', theme);
+      updateThemeIcon(theme);
     }
 
     function updateThemeIcon(theme) {
-      var icon = document.getElementById('theme-icon');
-      if (icon) icon.textContent = theme === 'dark' ? '\\u2600' : '\\u263E';
+      var sun = document.querySelector('.theme-icon-sun');
+      var moon = document.querySelector('.theme-icon-moon');
+      if (!sun || !moon) return;
+      // In dark mode, show the sun (switch-to-light). In light mode, show the moon.
+      if (theme === 'dark') {
+        sun.style.display = 'block';
+        moon.style.display = 'none';
+      } else {
+        sun.style.display = 'none';
+        moon.style.display = 'block';
+      }
     }
 
-    // ── Toast auto-dismiss ──
+    // Toast auto-dismiss
     var toastObserver = new MutationObserver(function() {
       document.querySelectorAll('.toast').forEach(function(t) {
         if (t.dataset.timer) return;

--- a/src/web/layout.ts
+++ b/src/web/layout.ts
@@ -1,0 +1,726 @@
+// HTML layout shell for the settings dashboard.
+// Pico CSS (classless) + HTMX loaded from CDN. Zero build step.
+// Custom teal/warm-gray design system with dark mode support.
+
+import { listProviders } from "../db/repositories/providers.js";
+import { listCategories } from "../db/repositories/categories.js";
+import { listUntranslatedGrouped } from "../db/repositories/translations.js";
+
+interface NavCounts {
+  providers?: number;
+  categories?: number;
+  untranslated?: number;
+}
+
+export function layout(title: string, currentPath: string, body: string, counts?: NavCounts): string {
+  // Auto-query counts if not provided
+  const c = counts ?? {
+    providers: listProviders().length,
+    categories: listCategories().length,
+    untranslated: listUntranslatedGrouped().length,
+  };
+
+  const navBadge = (n: number | undefined) =>
+    n != null && n > 0 ? ` <span class="nav-count">${n}</span>` : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)} — KolShek</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <style>
+    /* ── Typography ── */
+    :root, [data-theme="light"], [data-theme="dark"] {
+      --pico-font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      --pico-font-size: 15px;
+      --pico-line-height: 1.5;
+    }
+
+    /* ── Light theme (default) ── */
+    :root {
+      --pico-primary: #0d9488;
+      --pico-primary-background: #0d9488;
+      --pico-primary-hover: #0f766e;
+      --pico-primary-hover-background: #0f766e;
+      --pico-primary-focus: rgba(13, 148, 136, 0.125);
+      --pico-primary-inverse: #fff;
+      --pico-background-color: #f8fafc;
+      --pico-card-background-color: #ffffff;
+      --pico-card-sectioning-background-color: #f8fafc;
+      --pico-muted-color: #64748b;
+      --pico-muted-border-color: #e2e8f0;
+      --pico-form-element-border-color: #cbd5e1;
+      --pico-form-element-focus-color: var(--pico-primary);
+      --accent-gold: #d97706;
+      --surface: #ffffff;
+      --surface-hover: #f1f5f9;
+      --card-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+      --card-shadow-hover: 0 4px 12px rgba(0,0,0,0.08);
+      --badge-success-bg: #dcfce7;
+      --badge-success-fg: #166534;
+      --badge-danger-bg: #fef2f2;
+      --badge-danger-fg: #991b1b;
+      --badge-warning-bg: #fffbeb;
+      --badge-warning-fg: #92400e;
+      --condition-bg: #f0fdfa;
+      --condition-fg: #115e59;
+      --condition-border: #99f6e4;
+      --toast-shadow: 0 8px 24px rgba(0,0,0,0.12);
+      --empty-icon-color: #94a3b8;
+      --nav-bg: #ffffff;
+      --nav-border: #e2e8f0;
+      --nav-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    }
+
+    /* ── Dark theme ── */
+    [data-theme="dark"] {
+      --pico-primary: #2dd4bf;
+      --pico-primary-background: #0d9488;
+      --pico-primary-hover: #14b8a6;
+      --pico-primary-hover-background: #14b8a6;
+      --pico-primary-focus: rgba(45, 212, 191, 0.15);
+      --pico-primary-inverse: #042f2e;
+      --pico-background-color: #0c0f1a;
+      --pico-card-background-color: #141726;
+      --pico-card-sectioning-background-color: #111425;
+      --pico-color: #e2e8f0;
+      --pico-h1-color: #f1f5f9;
+      --pico-h2-color: #f1f5f9;
+      --pico-h3-color: #e2e8f0;
+      --pico-muted-color: #94a3b8;
+      --pico-muted-border-color: #1e293b;
+      --pico-form-element-background-color: #0f172a;
+      --pico-form-element-border-color: #334155;
+      --pico-form-element-focus-color: var(--pico-primary);
+      --surface: #141726;
+      --surface-hover: #1e2235;
+      --card-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
+      --card-shadow-hover: 0 4px 12px rgba(0,0,0,0.4);
+      --badge-success-bg: rgba(34, 197, 94, 0.15);
+      --badge-success-fg: #86efac;
+      --badge-danger-bg: rgba(239, 68, 68, 0.15);
+      --badge-danger-fg: #fca5a5;
+      --badge-warning-bg: rgba(245, 158, 11, 0.15);
+      --badge-warning-fg: #fcd34d;
+      --condition-bg: rgba(45, 212, 191, 0.1);
+      --condition-fg: #5eead4;
+      --condition-border: rgba(45, 212, 191, 0.2);
+      --toast-shadow: 0 8px 24px rgba(0,0,0,0.4);
+      --empty-icon-color: #475569;
+      --nav-bg: #111425;
+      --nav-border: #1e293b;
+      --nav-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+
+    /* ── Global transitions ── */
+    html { transition: background-color 0.2s ease; }
+    body { transition: color 0.2s ease; }
+
+    /* ── Nav ── */
+    header.container {
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--nav-border);
+      box-shadow: var(--nav-shadow);
+      margin-bottom: 2rem;
+      max-width: 100%;
+      padding: 0;
+    }
+    header.container nav {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+    header.container nav > ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    header.container nav > ul:last-child {
+      gap: 0.75rem;
+    }
+    nav a {
+      text-decoration: none;
+      color: var(--pico-muted-color);
+      font-weight: 500;
+      font-size: 0.9rem;
+      padding: 0.75rem 0;
+      transition: color 0.15s;
+    }
+    nav a:hover { color: var(--pico-color, #1e293b); }
+    nav a[aria-current="page"] {
+      color: var(--pico-primary);
+      border-bottom: 2px solid var(--pico-primary);
+      padding-bottom: calc(0.75rem - 2px);
+      text-decoration: none;
+    }
+    nav strong {
+      font-size: 1.05rem;
+      letter-spacing: -0.02em;
+    }
+    .nav-count {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.2rem;
+      height: 1.2rem;
+      padding: 0 0.3rem;
+      margin-left: 0.3rem;
+      font-size: 0.65rem;
+      font-weight: 700;
+      border-radius: 9999px;
+      background: var(--pico-primary);
+      color: var(--pico-primary-inverse);
+      vertical-align: middle;
+    }
+    #theme-toggle {
+      background: none;
+      border: 1px solid var(--pico-muted-border-color);
+      border-radius: 0.375rem;
+      padding: 0.35rem 0.55rem;
+      cursor: pointer;
+      font-size: 1.05rem;
+      color: var(--pico-muted-color);
+      transition: color 0.2s, border-color 0.2s, background 0.2s;
+      line-height: 1;
+      margin: 0;
+    }
+    #theme-toggle:hover {
+      color: var(--pico-primary);
+      border-color: var(--pico-primary);
+      background: var(--pico-primary-focus);
+    }
+
+    /* ── Main container ── */
+    main.container { max-width: 1200px; }
+
+    /* ── Page header ── */
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .page-header hgroup { margin-bottom: 0; }
+    .page-header hgroup h2 { margin-bottom: 0.1rem; font-size: 1.6rem; letter-spacing: -0.02em; }
+    .page-header hgroup p { margin-bottom: 0; }
+
+    /* ── Cards / Articles ── */
+    article {
+      border: 1px solid var(--pico-muted-border-color);
+      border-radius: 0.75rem;
+      background: var(--surface);
+      box-shadow: var(--card-shadow);
+      transition: box-shadow 0.2s;
+      overflow: hidden;
+      margin-bottom: 1.25rem;
+      padding: 0;
+    }
+    article > table,
+    article > details,
+    article > form,
+    article > div,
+    article > header,
+    article > p,
+    article > fieldset {
+      margin: 0;
+    }
+    // Override Pico's default article padding — we want tighter cards
+    article { padding: 1.25rem; }
+    article header {
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      margin: -1.25rem -1.25rem 1rem -1.25rem;
+      padding: 0.85rem 1.25rem;
+      background: var(--pico-card-sectioning-background-color);
+    }
+
+    /* ── Badges (pills) ── */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.2rem 0.6rem;
+      border-radius: 9999px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      white-space: nowrap;
+      line-height: 1.4;
+      letter-spacing: 0.01em;
+    }
+    .badge-success {
+      background: var(--badge-success-bg);
+      color: var(--badge-success-fg);
+    }
+    .badge-danger {
+      background: var(--badge-danger-bg);
+      color: var(--badge-danger-fg);
+    }
+    .badge-warning {
+      background: var(--badge-warning-bg);
+      color: var(--badge-warning-fg);
+    }
+
+    /* ── Condition tags ── */
+    .condition-tag {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      margin: 0.1rem 0.15rem;
+      font-size: 0.75rem;
+      font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
+      background: var(--condition-bg);
+      color: var(--condition-fg);
+      border: 1px solid var(--condition-border);
+      border-radius: 0.3rem;
+      white-space: nowrap;
+    }
+
+    /* ── Empty states ── */
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 3rem 1rem;
+      text-align: center;
+    }
+    .empty-state .empty-icon {
+      font-size: 2.5rem;
+      color: var(--empty-icon-color);
+      line-height: 1;
+      margin-bottom: 0.25rem;
+    }
+    .empty-state p {
+      margin: 0;
+      max-width: 26rem;
+    }
+    .empty-state .text-muted {
+      font-size: 0.85rem;
+    }
+
+    /* ── Tables ── */
+    table { margin-bottom: 0; }
+    .card-table { width: 100%; }
+    .card-table thead th {
+      font-size: 0.78rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--pico-muted-color);
+      padding: 0.65rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+    }
+    .card-table tbody td {
+      padding: 0.7rem 1rem;
+      font-size: 0.9rem;
+      vertical-align: middle;
+    }
+    .card-table tbody tr {
+      transition: background 0.12s;
+    }
+    .card-table tbody tr:hover {
+      background: var(--surface-hover);
+    }
+    .card-table tbody tr:not(:last-child) td {
+      border-bottom: 1px solid var(--pico-muted-border-color);
+    }
+    .card-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    /* ── Responsive: table → cards at 576px ── */
+    @media (max-width: 576px) {
+      .page-header {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .page-header button,
+      .page-header a[role="button"] {
+        width: 100%;
+      }
+      .card-table thead { display: none; }
+      .card-table tbody tr {
+        display: block;
+        margin-bottom: 0.75rem;
+        padding: 0.75rem;
+        border: 1px solid var(--pico-muted-border-color);
+        border-radius: 0.5rem;
+        background: var(--surface);
+      }
+      .card-table tbody td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.3rem 0;
+        border: none !important;
+      }
+      .card-table tbody td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        margin-right: 1rem;
+        flex-shrink: 0;
+        font-size: 0.8rem;
+        color: var(--pico-muted-color);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .card-table tbody td:empty { display: none; }
+      .card-table tbody td[data-label=""] { justify-content: flex-end; }
+      .card-table tbody td[data-label=""]::before { display: none; }
+    }
+
+    /* ── Actions ── */
+    .actions {
+      display: flex;
+      gap: 0.35rem;
+      justify-content: flex-end;
+    }
+    .actions button {
+      padding: 0.3rem 0.55rem;
+      font-size: 0.82rem;
+      margin: 0;
+      border-radius: 0.375rem;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+
+    /* ── Toasts ── */
+    #toast-container {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 999;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      max-width: 22rem;
+    }
+    .toast {
+      position: relative;
+      padding: 0.75rem 1.25rem;
+      border-radius: 0.625rem;
+      color: #fff;
+      box-shadow: var(--toast-shadow);
+      animation: toastSlideIn 0.25s ease-out;
+      line-height: 1.4;
+      font-size: 0.88rem;
+      backdrop-filter: blur(8px);
+    }
+    .toast-success { background: rgba(22, 163, 74, 0.95); }
+    .toast-error {
+      background: rgba(220, 38, 38, 0.95);
+      padding-right: 2.5rem;
+    }
+    .toast-close {
+      position: absolute;
+      top: 0.4rem;
+      right: 0.5rem;
+      background: none;
+      border: none;
+      color: rgba(255,255,255,0.7);
+      font-size: 1.1rem;
+      cursor: pointer;
+      padding: 0.15rem 0.35rem;
+      line-height: 1;
+      margin: 0;
+      border-radius: 0.25rem;
+      transition: color 0.15s;
+    }
+    .toast-close:hover { color: #fff; }
+    .toast.removing {
+      animation: toastFadeOut 0.3s ease-out forwards;
+    }
+    @keyframes toastSlideIn {
+      from { opacity: 0; transform: translateX(1rem); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes toastFadeOut {
+      from { opacity: 1; transform: translateY(0); }
+      to   { opacity: 0; transform: translateY(-0.5rem); }
+    }
+
+    /* ── Row highlight (newly added) ── */
+    @keyframes highlightRow {
+      from { background: var(--pico-primary-focus); }
+      to   { background: transparent; }
+    }
+    .highlight-new { animation: highlightRow 1.5s ease-out; }
+
+    /* ── Misc ── */
+    .text-muted { color: var(--pico-muted-color); font-size: 0.875rem; }
+    details[open] summary { margin-bottom: 1rem; }
+    details summary[role="button"].outline {
+      width: 100%;
+      text-align: center;
+      border-radius: 0.5rem;
+    }
+    fieldset {
+      border: 1px solid var(--pico-muted-border-color);
+      border-radius: 0.5rem;
+      padding: 1rem;
+    }
+    h2 { letter-spacing: -0.02em; }
+    h3, h4 { letter-spacing: -0.01em; }
+
+    /* ── Button polish ── */
+    button, [role="button"] {
+      border-radius: 0.5rem;
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      transition: all 0.15s ease;
+    }
+    input, select, textarea {
+      border-radius: 0.5rem !important;
+    }
+
+    /* ── Provider cards ── */
+    .provider-card {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+    }
+    .provider-card:last-child { border-bottom: none; }
+    .provider-card-info { flex: 1; min-width: 0; }
+    .provider-card-name { font-weight: 600; font-size: 0.95rem; }
+    .provider-card-meta { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; font-size: 0.82rem; color: var(--pico-muted-color); margin-top: 0.2rem; }
+    .provider-card-meta .separator { opacity: 0.4; }
+    .provider-card-actions { display: flex; gap: 0.35rem; flex-shrink: 0; }
+    .provider-card-actions button { padding: 0.3rem 0.6rem; font-size: 0.8rem; margin: 0; }
+    .provider-add-card {
+      border: 2px dashed var(--pico-muted-border-color);
+      background: transparent;
+      box-shadow: none;
+      cursor: pointer;
+      text-align: center;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .provider-add-card:hover {
+      border-color: var(--pico-primary);
+      background: var(--pico-primary-focus);
+    }
+
+    /* ── Categories layout ── */
+    .categories-layout {
+      display: grid;
+      grid-template-columns: minmax(220px, 280px) 1fr;
+      gap: 1.5rem;
+      align-items: start;
+    }
+    .category-sidebar { position: sticky; top: 1rem; }
+    .category-list { list-style: none; padding: 0; margin: 0; }
+    .category-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      border-left: 3px solid transparent;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s;
+      font-size: 0.9rem;
+      text-decoration: none;
+      color: inherit;
+    }
+    .category-item:hover { background: var(--surface-hover); }
+    .category-item.active {
+      background: var(--pico-primary-focus);
+      border-left-color: var(--pico-primary);
+      font-weight: 600;
+    }
+    .category-item.uncategorized { border-left-color: var(--accent-gold); }
+    .category-item .cat-count {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--pico-muted-color);
+      min-width: 1.5rem;
+      text-align: right;
+    }
+
+    /* ── Transaction rows ── */
+    .tx-row {
+      display: grid;
+      grid-template-columns: 4.5rem 1fr auto auto;
+      gap: 0.75rem;
+      align-items: center;
+      padding: 0.6rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      transition: background 0.12s;
+    }
+    .tx-row:last-child { border-bottom: none; }
+    .tx-row:hover { background: var(--surface-hover); }
+    .tx-date { font-size: 0.82rem; color: var(--pico-muted-color); white-space: nowrap; }
+    .tx-desc { min-width: 0; overflow: hidden; }
+    .tx-desc-he { direction: rtl; unicode-bidi: isolate; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.9rem; }
+    .tx-desc-en { display: block; font-size: 0.78rem; color: var(--pico-muted-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tx-amount { font-size: 0.9rem; font-weight: 500; white-space: nowrap; text-align: right; font-variant-numeric: tabular-nums; }
+    .tx-amount-expense { color: var(--badge-danger-fg); }
+    .tx-amount-income { color: var(--badge-success-fg); }
+    .inline-select { margin: 0; padding: 0.25rem 0.5rem; font-size: 0.82rem; height: auto; min-width: 8rem; }
+    .tx-row--moved {
+      background: var(--badge-success-bg);
+      opacity: 0.7;
+      pointer-events: none;
+      animation: txFadeOut 0.6s 0.4s ease-out forwards;
+    }
+    @keyframes txFadeOut {
+      to { opacity: 0; height: 0; padding: 0; border: none; overflow: hidden; }
+    }
+
+    /* ── Category action panel (inline confirm) ── */
+    .category-action-panel {
+      padding: 1rem 1.25rem;
+      background: var(--pico-primary-focus);
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.9rem;
+    }
+    .category-action-panel select { margin: 0; min-width: 10rem; }
+    .category-action-panel button { margin: 0; }
+
+    /* ── Translation rows ── */
+    .translate-row {
+      display: grid;
+      grid-template-columns: minmax(120px, 1fr) auto minmax(200px, 1.2fr) auto;
+      gap: 0.75rem;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+    }
+    .translate-row:last-child { border-bottom: none; }
+    .translate-source { direction: rtl; unicode-bidi: isolate; text-align: right; font-size: 0.9rem; }
+    .translate-source-meta { font-size: 0.78rem; color: var(--pico-muted-color); direction: ltr; }
+    .translate-arrow { color: var(--pico-muted-color); font-size: 1.1rem; text-align: center; }
+    .translate-input-group { display: flex; gap: 0.5rem; align-items: center; }
+    .translate-input-group input[type="text"] { margin: 0; font-size: 0.88rem; }
+    .translate-input-group label { font-size: 0.78rem; white-space: nowrap; display: flex; align-items: center; gap: 0.25rem; margin: 0; }
+    .translate-input-group label input[type="checkbox"] { margin: 0; width: auto; }
+    .translate-row-success {
+      background: var(--badge-success-bg);
+      color: var(--badge-success-fg);
+      font-size: 0.88rem;
+      animation: translateFade 2s ease-out forwards;
+    }
+    @keyframes translateFade {
+      0%, 70% { opacity: 1; max-height: 4rem; padding: 0.75rem 1rem; }
+      100% { opacity: 0; max-height: 0; padding: 0; overflow: hidden; border: none; }
+    }
+
+    /* ── Mobile: categories layout ── */
+    @media (max-width: 768px) {
+      .categories-layout { grid-template-columns: 1fr; }
+      .category-sidebar { position: sticky; top: 0; z-index: 10; background: var(--pico-background-color); padding: 0.5rem 0; border-bottom: 1px solid var(--pico-muted-border-color); }
+      .category-list { display: flex; overflow-x: auto; gap: 0.35rem; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
+      .category-item { flex-shrink: 0; border-radius: 9999px; border: 1px solid var(--pico-muted-border-color); font-size: 0.82rem; white-space: nowrap; border-left: none; padding: 0.35rem 0.75rem; }
+      .category-item.active { border-color: var(--pico-primary); }
+      .category-item.uncategorized { border-color: var(--accent-gold); }
+      .tx-row { grid-template-columns: 1fr; gap: 0.25rem; }
+      .tx-date { font-size: 0.75rem; }
+      .inline-select { width: 100%; }
+      .translate-row { grid-template-columns: 1fr; }
+      .translate-arrow { display: none; }
+      .provider-card { flex-direction: column; align-items: stretch; gap: 0.75rem; }
+      .provider-card-actions { justify-content: flex-end; }
+    }
+
+    /* ── Reduced motion ── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="container">
+    <nav>
+      <ul>
+        <li><strong>&#9670; KolShek</strong></li>
+      </ul>
+      <ul>
+        <li><a href="/providers"${currentPath === "/providers" ? ' aria-current="page"' : ""}>Providers${navBadge(c.providers)}</a></li>
+        <li><a href="/categories"${currentPath === "/categories" ? ' aria-current="page"' : ""}>Categories${navBadge(c.categories)}</a></li>
+        <li><a href="/translations"${currentPath === "/translations" ? ' aria-current="page"' : ""}>Translations${navBadge(c.untranslated)}</a></li>
+        <li>
+          <button id="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode">
+            <span id="theme-icon"></span>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </header>
+  <main class="container">
+    ${body}
+  </main>
+  <div id="toast-container" hx-swap-oob="true"></div>
+  <script>
+    // ── Dark mode ──
+    (function() {
+      var stored = localStorage.getItem('kolshek-theme');
+      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var theme = stored || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+      updateThemeIcon(theme);
+    })();
+
+    function toggleTheme() {
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('kolshek-theme', next);
+      updateThemeIcon(next);
+    }
+
+    function updateThemeIcon(theme) {
+      var icon = document.getElementById('theme-icon');
+      if (icon) icon.textContent = theme === 'dark' ? '\\u2600' : '\\u263E';
+    }
+
+    // ── Toast auto-dismiss ──
+    var toastObserver = new MutationObserver(function() {
+      document.querySelectorAll('.toast').forEach(function(t) {
+        if (t.dataset.timer) return;
+        t.dataset.timer = '1';
+        var isError = t.classList.contains('toast-error');
+        var delay = isError ? 10000 : 4000;
+
+        var closeBtn = t.querySelector('.toast-close');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', function() {
+            t.classList.add('removing');
+            setTimeout(function() { t.remove(); }, 300);
+          });
+        }
+
+        setTimeout(function() {
+          if (t.parentNode) {
+            t.classList.add('removing');
+            setTimeout(function() { t.remove(); }, 300);
+          }
+        }, delay);
+      });
+    });
+    toastObserver.observe(document.getElementById('toast-container'), { childList: true, subtree: true });
+  </script>
+</body>
+</html>`;
+}
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/web/pages/categories.ts
+++ b/src/web/pages/categories.ts
@@ -1,4 +1,4 @@
-// Categories page — two sections: Category Manager (CRUD) + Transaction Triage (master-detail).
+// Categories page -- two sections: Category Manager (CRUD) + Transaction Triage (master-detail).
 
 import { layout } from "../layout.js";
 import { categorySummaryTable } from "../partials/category-summary-table.js";
@@ -22,103 +22,121 @@ export function categoriesPage(activeCategory?: string): string {
 
   const body = `
     <!-- Category Manager -->
-    <article>
-      <header style="display:flex;justify-content:space-between;align-items:center;">
-        <strong>Categories</strong>
-        <form hx-post="/api/categories" hx-target="#category-summary-tbody" hx-swap="outerHTML"
-          hx-on::after-request="if(event.detail.successful) this.reset()"
-          style="display:flex;gap:0.5rem;margin:0;">
-          <input type="text" name="name" placeholder="New category name..." required
-            style="margin:0;padding:0.3rem 0.6rem;font-size:0.85rem;height:auto;min-width:10rem;">
-          <button type="submit" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">+ Add</button>
+    <div class="card">
+      <div class="card-header">
+        <div class="flex items-center gap-2.5">
+          <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-emerald-50 dark:bg-emerald-900/20">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-600 dark:text-emerald-400"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+          </div>
+          <span class="font-semibold text-sm text-zinc-900 dark:text-white">Categories</span>
+        </div>
+        <form class="flex items-center gap-2" hx-post="/api/categories" hx-target="#category-summary-tbody" hx-swap="outerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset()">
+          <input type="text" name="name" placeholder="New category..." required
+            class="!w-44 !py-1.5 !text-sm">
+          <button type="submit" class="btn btn-outline btn-sm">+ Add</button>
         </form>
-      </header>
+      </div>
 
       <div id="category-action-panel"></div>
 
-      <table role="grid" class="card-table" style="margin:0;">
+      <table class="w-full text-sm">
         <thead>
-          <tr>
-            <th>Category</th>
-            <th>Transactions</th>
-            <th>Total</th>
-            <th>Source</th>
-            <th></th>
+          <tr class="border-b border-zinc-200 dark:border-zinc-800">
+            <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-left">Category</th>
+            <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-left">Transactions</th>
+            <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-right">Total</th>
+            <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5"></th>
           </tr>
         </thead>
         ${categorySummaryTable()}
       </table>
-    </article>
+    </div>
 
     <!-- Transaction Triage -->
-    <article style="padding:0;overflow:visible;">
-      <header>
-        <strong>Transactions</strong>
-        <span class="text-muted" style="font-weight:400;margin-left:0.5rem;">${totalTx} total${uncatCount > 0 ? `, ${uncatCount} uncategorized` : ""}</span>
-      </header>
+    <div class="card mt-6">
+      <div class="card-header">
+        <div class="flex items-center gap-2.5">
+          <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 dark:bg-indigo-900/20">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-600 dark:text-indigo-400"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+          </div>
+          <span class="font-semibold text-sm text-zinc-900 dark:text-white">Transactions</span>
+          ${uncatCount > 0 ? `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">${uncatCount} uncategorized</span>` : ""}
+          <span class="text-zinc-400 dark:text-zinc-400 text-xs font-normal">${totalTx} total</span>
+        </div>
+      </div>
 
       ${totalTx === 0
-        ? `<div class="empty-state">
-            <span class="empty-icon">&#128176;</span>
-            <p>No transactions yet</p>
-            <p class="text-muted">Sync your bank accounts from the <a href="/providers">Providers</a> page to see transactions here.</p>
+        ? `<div class="flex flex-col items-center gap-3 py-14 text-center">
+            <div class="flex items-center justify-center w-14 h-14 rounded-2xl bg-zinc-100 dark:bg-zinc-800 mb-1">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="text-zinc-400 dark:text-zinc-500"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+            </div>
+            <p class="text-sm font-semibold text-zinc-800 dark:text-zinc-200">No transactions yet</p>
+            <p class="text-zinc-500 dark:text-zinc-300 text-sm max-w-xs">Sync your bank accounts from the <a href="/providers" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">Providers</a> page to see transactions here.</p>
           </div>`
-        : `<div class="categories-layout" style="padding:1rem;">
-            ${categorySidebar(selectedCat)}
+        : `<div class="grid grid-cols-[14rem_1fr] gap-0 divide-x divide-zinc-200 dark:divide-zinc-800 p-0">
+            <div class="bg-zinc-50/50 dark:bg-zinc-900/30">${categorySidebar(selectedCat)}</div>
             ${categoryTxPanel(selectedCat)}
           </div>`
       }
-    </article>
+    </div>
 
     <!-- Category Rules (collapsible) -->
-    <article>
+    <div class="card mt-6">
       <details${rules.length === 0 ? " open" : ""}>
-        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
-          Category Rules <span class="text-muted" style="font-weight:400;">(${rules.length})</span>
+        <summary class="card-header cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
+          <div class="flex items-center gap-2.5">
+            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-amber-50 dark:bg-amber-900/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-600 dark:text-amber-400"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            </div>
+            <span class="font-semibold text-sm text-zinc-900 dark:text-white">Category Rules</span>
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded-md text-xs font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 tabular-nums">${rules.length}</span>
+          </div>
+          <svg class="w-4 h-4 text-zinc-400 transition-transform [[open]>&]:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
         </summary>
-        <div style="padding:0 1.25rem 1rem;">
-          <div style="display:flex;justify-content:flex-end;gap:0.5rem;margin-bottom:0.75rem;">
-            <form hx-post="/api/categories/apply" hx-target="#category-summary-tbody" hx-swap="outerHTML" style="display:flex;gap:0.5rem;margin:0;">
-              <select name="scope" style="margin:0;font-size:0.85rem;padding:0.3rem;height:auto;">
+        <div class="p-5">
+          <div class="flex justify-end gap-2 mb-3">
+            <form class="flex items-center gap-2" hx-post="/api/categories/apply" hx-target="#category-summary-tbody" hx-swap="outerHTML">
+              <select name="scope" class="!w-auto !py-1 !text-xs !px-2">
                 <option value="uncategorized">Uncategorized only</option>
                 <option value="all">All transactions</option>
               </select>
-              <button type="submit" hx-disabled-elt="this" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Apply</button>
+              <button type="submit" class="btn btn-primary btn-sm" hx-disabled-elt="this">Apply</button>
             </form>
           </div>
 
-          <table role="grid" class="card-table">
+          <table class="w-full text-sm">
             <thead>
-              <tr>
-                <th>Category</th>
-                <th>Conditions</th>
-                <th>Priority</th>
-                <th></th>
+              <tr class="border-b border-zinc-200 dark:border-zinc-800">
+                <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-left">Category</th>
+                <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-left">Conditions</th>
+                <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5 text-right">Priority</th>
+                <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-2.5"></th>
               </tr>
             </thead>
             ${categoryRulesTableBody(rules)}
           </table>
 
-          <details style="margin-top:1rem;">
-            <summary role="button" class="outline" style="text-align:center;">+ Add Rule</summary>
-            <form hx-post="/api/categories/rules" hx-target="#category-rules-tbody" hx-swap="outerHTML"
+          <details class="mt-4">
+            <summary class="btn btn-outline w-full justify-center cursor-pointer list-none [&::-webkit-details-marker]:hidden">+ Add Rule</summary>
+            <form class="mt-4 space-y-4" hx-post="/api/categories/rules" hx-target="#category-rules-tbody" hx-swap="outerHTML"
               hx-on::after-request="if(event.detail.successful) this.reset()">
-              <div class="grid">
+              <div class="grid grid-cols-2 gap-4">
                 <label>
                   Category
                   <input type="text" name="category" placeholder="e.g. Groceries" required>
                 </label>
                 <label>
-                  Priority <small class="text-muted">(higher = first)</small>
+                  Priority <small class="text-zinc-500 dark:text-zinc-300 text-xs font-normal">(higher = first)</small>
                   <input type="number" name="priority" value="10">
                 </label>
               </div>
-              <fieldset>
-                <legend>Conditions</legend>
-                <div class="grid">
+              <fieldset class="border border-zinc-200 dark:border-zinc-700 rounded-lg p-4">
+                <legend class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 px-2">Conditions</legend>
+                <div class="grid grid-cols-2 gap-4">
                   <label>
                     Description pattern
-                    <input type="text" name="descriptionPattern" placeholder="e.g. שופרסל">
+                    <input type="text" name="descriptionPattern" placeholder="e.g. &#1513;&#1493;&#1508;&#1512;&#1505;&#1500;">
                   </label>
                   <label>
                     Match mode
@@ -129,13 +147,13 @@ export function categoriesPage(activeCategory?: string): string {
                     </select>
                   </label>
                 </div>
-                <div class="grid">
+                <div class="grid grid-cols-2 gap-4 mt-3">
                   <label>
-                    Memo pattern <small class="text-muted">(optional)</small>
+                    Memo pattern <small class="text-zinc-500 dark:text-zinc-300 text-xs font-normal">(optional)</small>
                     <input type="text" name="memoPattern">
                   </label>
                   <label>
-                    Direction <small class="text-muted">(optional)</small>
+                    Direction <small class="text-zinc-500 dark:text-zinc-300 text-xs font-normal">(optional)</small>
                     <select name="direction">
                       <option value="">Any</option>
                       <option value="debit">Expense (debit)</option>
@@ -144,12 +162,12 @@ export function categoriesPage(activeCategory?: string): string {
                   </label>
                 </div>
               </fieldset>
-              <button type="submit" hx-disabled-elt="this">Add Rule</button>
+              <button type="submit" class="btn btn-primary" hx-disabled-elt="this">Add Rule</button>
             </form>
           </details>
         </div>
       </details>
-    </article>`;
+    </div>`;
 
   return layout("Categories", "/categories", body);
 }

--- a/src/web/pages/categories.ts
+++ b/src/web/pages/categories.ts
@@ -1,0 +1,155 @@
+// Categories page — two sections: Category Manager (CRUD) + Transaction Triage (master-detail).
+
+import { layout } from "../layout.js";
+import { categorySummaryTable } from "../partials/category-summary-table.js";
+import { categorySidebar } from "../partials/category-sidebar.js";
+import { categoryTxPanel } from "../partials/category-tx-panel.js";
+import { categoryRulesTableBody } from "../partials/category-rules-table.js";
+import { listCategoryRules, listCategories } from "../../db/repositories/categories.js";
+import { countTransactions } from "../../db/repositories/transactions.js";
+
+export function categoriesPage(activeCategory?: string): string {
+  const categories = listCategories();
+  const rules = listCategoryRules();
+  const totalTx = countTransactions();
+  const uncatCount = countTransactions({ category: null });
+
+  // Default to Uncategorized if it has items, otherwise first category
+  const defaultCat = uncatCount > 0
+    ? "Uncategorized"
+    : (categories[0]?.category ?? "Uncategorized");
+  const selectedCat = activeCategory ?? defaultCat;
+
+  const body = `
+    <!-- Category Manager -->
+    <article>
+      <header style="display:flex;justify-content:space-between;align-items:center;">
+        <strong>Categories</strong>
+        <form hx-post="/api/categories" hx-target="#category-summary-tbody" hx-swap="outerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset()"
+          style="display:flex;gap:0.5rem;margin:0;">
+          <input type="text" name="name" placeholder="New category name..." required
+            style="margin:0;padding:0.3rem 0.6rem;font-size:0.85rem;height:auto;min-width:10rem;">
+          <button type="submit" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">+ Add</button>
+        </form>
+      </header>
+
+      <div id="category-action-panel"></div>
+
+      <table role="grid" class="card-table" style="margin:0;">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Transactions</th>
+            <th>Total</th>
+            <th>Source</th>
+            <th></th>
+          </tr>
+        </thead>
+        ${categorySummaryTable()}
+      </table>
+    </article>
+
+    <!-- Transaction Triage -->
+    <article style="padding:0;overflow:visible;">
+      <header>
+        <strong>Transactions</strong>
+        <span class="text-muted" style="font-weight:400;margin-left:0.5rem;">${totalTx} total${uncatCount > 0 ? `, ${uncatCount} uncategorized` : ""}</span>
+      </header>
+
+      ${totalTx === 0
+        ? `<div class="empty-state">
+            <span class="empty-icon">&#128176;</span>
+            <p>No transactions yet</p>
+            <p class="text-muted">Sync your bank accounts from the <a href="/providers">Providers</a> page to see transactions here.</p>
+          </div>`
+        : `<div class="categories-layout" style="padding:1rem;">
+            ${categorySidebar(selectedCat)}
+            ${categoryTxPanel(selectedCat)}
+          </div>`
+      }
+    </article>
+
+    <!-- Category Rules (collapsible) -->
+    <article>
+      <details${rules.length === 0 ? " open" : ""}>
+        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
+          Category Rules <span class="text-muted" style="font-weight:400;">(${rules.length})</span>
+        </summary>
+        <div style="padding:0 1.25rem 1rem;">
+          <div style="display:flex;justify-content:flex-end;gap:0.5rem;margin-bottom:0.75rem;">
+            <form hx-post="/api/categories/apply" hx-target="#category-summary-tbody" hx-swap="outerHTML" style="display:flex;gap:0.5rem;margin:0;">
+              <select name="scope" style="margin:0;font-size:0.85rem;padding:0.3rem;height:auto;">
+                <option value="uncategorized">Uncategorized only</option>
+                <option value="all">All transactions</option>
+              </select>
+              <button type="submit" hx-disabled-elt="this" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Apply</button>
+            </form>
+          </div>
+
+          <table role="grid" class="card-table">
+            <thead>
+              <tr>
+                <th>Category</th>
+                <th>Conditions</th>
+                <th>Priority</th>
+                <th></th>
+              </tr>
+            </thead>
+            ${categoryRulesTableBody(rules)}
+          </table>
+
+          <details style="margin-top:1rem;">
+            <summary role="button" class="outline" style="text-align:center;">+ Add Rule</summary>
+            <form hx-post="/api/categories/rules" hx-target="#category-rules-tbody" hx-swap="outerHTML"
+              hx-on::after-request="if(event.detail.successful) this.reset()">
+              <div class="grid">
+                <label>
+                  Category
+                  <input type="text" name="category" placeholder="e.g. Groceries" required>
+                </label>
+                <label>
+                  Priority <small class="text-muted">(higher = first)</small>
+                  <input type="number" name="priority" value="10">
+                </label>
+              </div>
+              <fieldset>
+                <legend>Conditions</legend>
+                <div class="grid">
+                  <label>
+                    Description pattern
+                    <input type="text" name="descriptionPattern" placeholder="e.g. שופרסל">
+                  </label>
+                  <label>
+                    Match mode
+                    <select name="descriptionMode">
+                      <option value="substring">Contains (substring)</option>
+                      <option value="exact">Exact match</option>
+                      <option value="regex">Regex</option>
+                    </select>
+                  </label>
+                </div>
+                <div class="grid">
+                  <label>
+                    Memo pattern <small class="text-muted">(optional)</small>
+                    <input type="text" name="memoPattern">
+                  </label>
+                  <label>
+                    Direction <small class="text-muted">(optional)</small>
+                    <select name="direction">
+                      <option value="">Any</option>
+                      <option value="debit">Expense (debit)</option>
+                      <option value="credit">Income (credit)</option>
+                    </select>
+                  </label>
+                </div>
+              </fieldset>
+              <button type="submit" hx-disabled-elt="this">Add Rule</button>
+            </form>
+          </details>
+        </div>
+      </details>
+    </article>`;
+
+  return layout("Categories", "/categories", body);
+}

--- a/src/web/pages/providers.ts
+++ b/src/web/pages/providers.ts
@@ -22,35 +22,46 @@ export async function providersPage(): Promise<string> {
   const isEmpty = providers.length === 0;
 
   const body = `
-    <div class="page-header">
-      <hgroup>
-        <h2>Providers</h2>
-        <p>${providers.length} provider${providers.length !== 1 ? "s" : ""} configured</p>
-      </hgroup>
-      <button id="fetch-btn" onclick="startFetch(false)" ${isEmpty ? "disabled" : ""}>
+    <div class="flex items-center justify-between mb-6">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 shrink-0">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+        </div>
+        <div>
+          <h2 class="text-xl font-bold text-zinc-900 dark:text-white">Providers</h2>
+          <p class="text-zinc-500 dark:text-zinc-300 text-sm mt-0.5">${providers.length} provider${providers.length !== 1 ? "s" : ""} configured</p>
+        </div>
+      </div>
+      <button id="fetch-btn" class="btn btn-primary" onclick="startFetch(false)" ${isEmpty ? "disabled" : ""}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
         Fetch All
       </button>
     </div>
 
-    <article id="fetch-status-card" style="display:none;">
-      <progress id="fetch-progress"></progress>
-      <small id="fetch-message" class="text-muted"></small>
-    </article>
+    <div id="fetch-status-card" class="card p-4 mb-4" style="display:none;">
+      <div class="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-2 overflow-hidden">
+        <div id="fetch-progress" class="bg-indigo-600 h-2 rounded-full transition-all" style="width:100%; animation: pulse 1.5s ease-in-out infinite;"></div>
+      </div>
+      <p id="fetch-message" class="text-zinc-500 dark:text-zinc-300 text-sm mt-2"></p>
+    </div>
 
     <div id="fetch-results" style="display:none;"></div>
 
-    <article style="padding:0;">
+    <div class="card mb-4">
       ${providerCards(cards)}
-    </article>
+    </div>
 
     <div id="auth-form-container"></div>
 
-    <article class="provider-add-card" id="add-provider-card">
+    <div class="card" id="add-provider-card">
       <details${isEmpty ? " open" : ""}>
-        <summary role="button" class="outline" style="border:none;box-shadow:none;background:transparent;">+ Add Provider</summary>
-        <div style="padding:0 1.25rem 1.25rem;">
+        <summary class="flex items-center gap-2 px-5 py-3.5 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/10 transition-colors select-none">
+          <svg class="w-4 h-4 transition-transform [[open]>&]:rotate-45" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Add Provider
+        </summary>
+        <div class="px-5 pb-5 border-t border-zinc-200 dark:border-zinc-700 pt-4">
           <form hx-post="/api/providers" hx-target="#provider-cards" hx-swap="outerHTML" hx-on::after-request="if(event.detail.successful) this.reset()">
-            <div class="grid">
+            <div class="grid grid-cols-2 gap-4">
               <label>
                 Type
                 <select name="providerType" id="provider-type-select"
@@ -67,11 +78,11 @@ export async function providersPage(): Promise<string> {
                 </select>
               </label>
             </div>
-            <div id="dynamic-fields"></div>
+            <div id="dynamic-fields" class="mt-4"></div>
           </form>
         </div>
       </details>
-    </article>
+    </div>
 
     <script>
       var bankOptions = ${JSON.stringify(banks.map((b) => ({ value: b.companyId, label: b.displayName })))};
@@ -156,21 +167,21 @@ export async function providersPage(): Promise<string> {
             btn.removeAttribute('aria-busy');
 
             var hasFailures = false;
-            var html = '<article><table role="grid" class="card-table"><thead><tr><th>Provider</th><th>Status</th><th>Added</th><th>Updated</th></tr></thead><tbody>';
+            var html = '<div class="card"><div class="overflow-x-auto"><table class="w-full text-left"><thead><tr class="border-b border-zinc-200 dark:border-zinc-700"><th class="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50">Provider</th><th class="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50">Status</th><th class="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50">Added</th><th class="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50">Updated</th></tr></thead><tbody>';
             for (var i = 0; i < evt.results.length; i++) {
               var r = evt.results[i];
               var statusBadge = r.success
-                ? '<span class="badge badge-success">&#10003; OK</span>'
-                : '<span class="badge badge-danger">&#10007; Failed</span>';
-              html += '<tr><td>' + r.alias + '</td><td>' + statusBadge + (r.error ? ' <small class="text-muted">' + r.error + '</small>' : '') + '</td><td>' + r.added + '</td><td>' + r.updated + '</td></tr>';
+                ? '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">&#10003; OK</span>'
+                : '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300">&#10007; Failed</span>';
+              html += '<tr class="border-b border-zinc-100 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50"><td class="px-4 py-3 text-sm">' + r.alias + '</td><td class="px-4 py-3 text-sm">' + statusBadge + (r.error ? ' <span class="text-zinc-500 dark:text-zinc-300 text-sm ml-1">' + r.error + '</span>' : '') + '</td><td class="px-4 py-3 text-sm">' + r.added + '</td><td class="px-4 py-3 text-sm">' + r.updated + '</td></tr>';
               if (!r.success) hasFailures = true;
             }
-            html += '</tbody></table>';
+            html += '</tbody></table></div>';
 
             if (hasFailures) {
-              html += '<button onclick="startFetch(true)" class="outline secondary" style="margin-top:0.5rem;">Retry failed with visible browser (for OTP/2FA)</button>';
+              html += '<div class="px-4 py-3 border-t border-zinc-200 dark:border-zinc-700"><button onclick="startFetch(true)" class="btn btn-outline">Retry failed with visible browser (for OTP/2FA)</button></div>';
             }
-            html += '</article>';
+            html += '</div>';
 
             results.innerHTML = html;
             results.style.display = 'block';
@@ -182,7 +193,7 @@ export async function providersPage(): Promise<string> {
             btn.disabled = false;
             btn.textContent = 'Fetch All';
             btn.removeAttribute('aria-busy');
-            results.innerHTML = '<article><p><span class="badge badge-danger">Error</span> ' + evt.message + '</p><button onclick="startFetch(true)" class="outline secondary">Retry with visible browser</button></article>';
+            results.innerHTML = '<div class="card p-4"><p class="mb-3"><span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300">Error</span> ' + evt.message + '</p><button onclick="startFetch(true)" class="btn btn-outline">Retry with visible browser</button></div>';
             results.style.display = 'block';
           }
         }

--- a/src/web/pages/providers.ts
+++ b/src/web/pages/providers.ts
@@ -1,0 +1,205 @@
+// Providers page — card layout with per-provider fetch, auth, and add-card.
+
+import { layout } from "../layout.js";
+import { providerCards, type ProviderCardData } from "../partials/provider-cards.js";
+import { listProviders } from "../../db/repositories/providers.js";
+import { countTransactions } from "../../db/repositories/transactions.js";
+import { hasCredentials } from "../../security/keychain.js";
+import { getProvidersByType } from "../../types/provider.js";
+
+export async function providersPage(): Promise<string> {
+  const providers = listProviders();
+  const cards: ProviderCardData[] = await Promise.all(
+    providers.map(async (p) => ({
+      provider: p,
+      hasAuth: await hasCredentials(p.alias),
+      txCount: countTransactions({ providerId: p.id }),
+    })),
+  );
+
+  const banks = getProvidersByType("bank");
+  const creditCards = getProvidersByType("credit_card");
+  const isEmpty = providers.length === 0;
+
+  const body = `
+    <div class="page-header">
+      <hgroup>
+        <h2>Providers</h2>
+        <p>${providers.length} provider${providers.length !== 1 ? "s" : ""} configured</p>
+      </hgroup>
+      <button id="fetch-btn" onclick="startFetch(false)" ${isEmpty ? "disabled" : ""}>
+        Fetch All
+      </button>
+    </div>
+
+    <article id="fetch-status-card" style="display:none;">
+      <progress id="fetch-progress"></progress>
+      <small id="fetch-message" class="text-muted"></small>
+    </article>
+
+    <div id="fetch-results" style="display:none;"></div>
+
+    <article style="padding:0;">
+      ${providerCards(cards)}
+    </article>
+
+    <div id="auth-form-container"></div>
+
+    <article class="provider-add-card" id="add-provider-card">
+      <details${isEmpty ? " open" : ""}>
+        <summary role="button" class="outline" style="border:none;box-shadow:none;background:transparent;">+ Add Provider</summary>
+        <div style="padding:0 1.25rem 1.25rem;">
+          <form hx-post="/api/providers" hx-target="#provider-cards" hx-swap="outerHTML" hx-on::after-request="if(event.detail.successful) this.reset()">
+            <div class="grid">
+              <label>
+                Type
+                <select name="providerType" id="provider-type-select"
+                  hx-on:change="updateProviderOptions()">
+                  <option value="">Select type...</option>
+                  <option value="bank">Bank</option>
+                  <option value="credit_card">Credit Card</option>
+                </select>
+              </label>
+              <label>
+                Provider
+                <select name="providerSelect" id="provider-select" disabled>
+                  <option value="">Select provider...</option>
+                </select>
+              </label>
+            </div>
+            <div id="dynamic-fields"></div>
+          </form>
+        </div>
+      </details>
+    </article>
+
+    <script>
+      var bankOptions = ${JSON.stringify(banks.map((b) => ({ value: b.companyId, label: b.displayName })))};
+      var ccOptions = ${JSON.stringify(creditCards.map((c) => ({ value: c.companyId, label: c.displayName })))};
+
+      function updateProviderOptions() {
+        var typeSelect = document.getElementById('provider-type-select');
+        var provSelect = document.getElementById('provider-select');
+        var type = typeSelect.value;
+        var options = type === 'bank' ? bankOptions : type === 'credit_card' ? ccOptions : [];
+
+        provSelect.innerHTML = '<option value="">Select provider...</option>' +
+          options.map(function(o) { return '<option value="' + o.value + '">' + o.label + '</option>'; }).join('');
+        provSelect.disabled = !type;
+        document.getElementById('dynamic-fields').innerHTML = '';
+      }
+
+      document.getElementById('provider-select').addEventListener('change', function() {
+        var companyId = this.value;
+        if (!companyId) {
+          document.getElementById('dynamic-fields').innerHTML = '';
+          return;
+        }
+        htmx.ajax('GET', '/api/providers/fields/' + companyId, {target: '#dynamic-fields', swap: 'innerHTML'});
+      });
+
+      function startFetch(visible) {
+        var btn = document.getElementById('fetch-btn');
+        var statusCard = document.getElementById('fetch-status-card');
+        var msg = document.getElementById('fetch-message');
+        var results = document.getElementById('fetch-results');
+
+        btn.disabled = true;
+        btn.textContent = 'Fetching...';
+        btn.setAttribute('aria-busy', 'true');
+        statusCard.style.display = 'block';
+        results.style.display = 'none';
+        results.innerHTML = '';
+        msg.textContent = 'Starting...';
+
+        var reqBody = new URLSearchParams();
+        if (visible) reqBody.set('visible', '1');
+
+        fetch('/api/fetch', { method: 'POST', body: reqBody })
+          .then(function(response) {
+            var reader = response.body.getReader();
+            var decoder = new TextDecoder();
+            var buffer = '';
+
+            function read() {
+              reader.read().then(function(result) {
+                if (result.done) return;
+                buffer += decoder.decode(result.value, { stream: true });
+                var lines = buffer.split('\\n');
+                buffer = lines.pop();
+                for (var i = 0; i < lines.length; i++) {
+                  if (lines[i].startsWith('data: ')) {
+                    handleEvent(JSON.parse(lines[i].slice(6)));
+                  }
+                }
+                read();
+              });
+            }
+            read();
+          })
+          .catch(function(err) {
+            msg.textContent = 'Connection error: ' + err.message;
+            btn.disabled = false;
+            btn.textContent = 'Fetch All';
+            btn.removeAttribute('aria-busy');
+          });
+
+        function handleEvent(evt) {
+          if (evt.type === 'start') {
+            msg.textContent = 'Connecting to ' + evt.providers.length + ' provider(s)...' + (evt.visible ? ' (visible browser)' : '');
+          } else if (evt.type === 'progress') {
+            msg.textContent = evt.alias + ': ' + formatStage(evt.stage);
+          } else if (evt.type === 'done') {
+            statusCard.style.display = 'none';
+            btn.disabled = false;
+            btn.textContent = 'Fetch All';
+            btn.removeAttribute('aria-busy');
+
+            var hasFailures = false;
+            var html = '<article><table role="grid" class="card-table"><thead><tr><th>Provider</th><th>Status</th><th>Added</th><th>Updated</th></tr></thead><tbody>';
+            for (var i = 0; i < evt.results.length; i++) {
+              var r = evt.results[i];
+              var statusBadge = r.success
+                ? '<span class="badge badge-success">&#10003; OK</span>'
+                : '<span class="badge badge-danger">&#10007; Failed</span>';
+              html += '<tr><td>' + r.alias + '</td><td>' + statusBadge + (r.error ? ' <small class="text-muted">' + r.error + '</small>' : '') + '</td><td>' + r.added + '</td><td>' + r.updated + '</td></tr>';
+              if (!r.success) hasFailures = true;
+            }
+            html += '</tbody></table>';
+
+            if (hasFailures) {
+              html += '<button onclick="startFetch(true)" class="outline secondary" style="margin-top:0.5rem;">Retry failed with visible browser (for OTP/2FA)</button>';
+            }
+            html += '</article>';
+
+            results.innerHTML = html;
+            results.style.display = 'block';
+
+            // Refresh provider cards to update last synced times and tx counts
+            htmx.ajax('GET', '/api/providers/cards', {target: '#provider-cards', swap: 'outerHTML'});
+          } else if (evt.type === 'error') {
+            statusCard.style.display = 'none';
+            btn.disabled = false;
+            btn.textContent = 'Fetch All';
+            btn.removeAttribute('aria-busy');
+            results.innerHTML = '<article><p><span class="badge badge-danger">Error</span> ' + evt.message + '</p><button onclick="startFetch(true)" class="outline secondary">Retry with visible browser</button></article>';
+            results.style.display = 'block';
+          }
+        }
+
+        function formatStage(stage) {
+          var stages = {
+            loading_credentials: 'Loading credentials...',
+            scraping: 'Scraping transactions...',
+            processing: 'Processing data...',
+            logging_in: 'Logging in...',
+            waiting_for_page: 'Waiting for page...',
+            fetching_data: 'Fetching data...',
+          };
+          return stages[stage] || stage;
+        }
+      }
+    </script>`;
+
+  return layout("Providers", "/providers", body);
+}

--- a/src/web/pages/translations.ts
+++ b/src/web/pages/translations.ts
@@ -1,0 +1,95 @@
+// Translations page — untranslated-first grouped layout + translation rules + already translated.
+
+import { layout } from "../layout.js";
+import { untranslatedList } from "../partials/untranslated-list.js";
+import { translatedList } from "../partials/translated-list.js";
+import { translationRulesTableBody } from "../partials/translation-rules-table.js";
+import { listTranslationRules, listUntranslatedGrouped, listTranslatedGrouped } from "../../db/repositories/translations.js";
+
+export function translationsPage(): string {
+  const untranslated = listUntranslatedGrouped();
+  const translated = listTranslatedGrouped();
+  const rules = listTranslationRules();
+
+  const body = `
+    <!-- Untranslated Transactions (primary) -->
+    <article>
+      <header style="display:flex;justify-content:space-between;align-items:center;">
+        <strong>Untranslated <span class="text-muted" style="font-weight:400;">(${untranslated.length} merchant name${untranslated.length !== 1 ? "s" : ""})</span></strong>
+        <form hx-post="/api/translations/apply" hx-target="#toast-container" hx-swap="afterbegin"
+          hx-on::after-request="if(event.detail.successful) htmx.ajax('GET','/api/translations/untranslated','#untranslated-list')"
+          style="margin:0;">
+          <button type="submit" class="outline" hx-disabled-elt="this" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Apply All Rules</button>
+        </form>
+      </header>
+      ${untranslatedList()}
+    </article>
+
+    <!-- Translation Rules (collapsible) -->
+    <article>
+      <details${rules.length === 0 ? " open" : ""}>
+        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
+          Translation Rules <span class="text-muted" style="font-weight:400;">(${rules.length})</span>
+        </summary>
+        <div style="padding:0 1.25rem 1rem;">
+          <table role="grid" class="card-table">
+            <thead>
+              <tr>
+                <th>English Name</th>
+                <th>Match Pattern (Hebrew)</th>
+                <th>Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            ${translationRulesTableBody(rules)}
+          </table>
+
+          <details style="margin-top:1rem;">
+            <summary role="button" class="outline" style="text-align:center;">+ Add Rule</summary>
+            <form hx-post="/api/translations/rules" hx-target="#translation-rules-tbody" hx-swap="outerHTML"
+              hx-on::after-request="if(event.detail.successful) this.reset()">
+              <div class="grid">
+                <label>
+                  English Name
+                  <input type="text" name="englishName" required placeholder="e.g. Shufersal">
+                </label>
+                <label>
+                  Match Pattern (Hebrew)
+                  <input type="text" name="matchPattern" required placeholder="e.g. &#1513;&#1493;&#1508;&#1512;&#1505;&#1500;" dir="rtl">
+                </label>
+              </div>
+              <button type="submit" hx-disabled-elt="this">Add Rule</button>
+            </form>
+          </details>
+        </div>
+      </details>
+    </article>
+
+    <!-- Already Translated (collapsible) -->
+    <article>
+      <details${translated.length > 0 && untranslated.length === 0 ? " open" : ""}>
+        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
+          Translated <span class="text-muted" style="font-weight:400;">(${translated.length} merchant name${translated.length !== 1 ? "s" : ""})</span>
+        </summary>
+        <div style="padding:0 1.25rem 1rem;">
+          <input type="search" id="translate-filter" placeholder="Filter by name..."
+            style="margin:0 0 0.75rem;padding:0.4rem 0.75rem;font-size:0.85rem;"
+            oninput="filterTranslated(this.value)">
+          ${translatedList()}
+        </div>
+      </details>
+    </article>
+
+    <script>
+      function filterTranslated(query) {
+        var q = query.toLowerCase();
+        var rows = document.querySelectorAll('#translated-list .translate-row');
+        for (var i = 0; i < rows.length; i++) {
+          var text = rows[i].textContent.toLowerCase();
+          rows[i].style.display = text.indexOf(q) !== -1 ? '' : 'none';
+        }
+      }
+    </script>`;
+
+  return layout("Translations", "/translations", body);
+}

--- a/src/web/pages/translations.ts
+++ b/src/web/pages/translations.ts
@@ -1,4 +1,4 @@
-// Translations page — untranslated-first grouped layout + translation rules + already translated.
+// Translations page -- untranslated-first grouped layout + translation rules + already translated.
 
 import { layout } from "../layout.js";
 import { untranslatedList } from "../partials/untranslated-list.js";
@@ -12,43 +12,64 @@ export function translationsPage(): string {
   const rules = listTranslationRules();
 
   const body = `
-    <!-- Untranslated Transactions (primary) -->
-    <article>
-      <header style="display:flex;justify-content:space-between;align-items:center;">
-        <strong>Untranslated <span class="text-muted" style="font-weight:400;">(${untranslated.length} merchant name${untranslated.length !== 1 ? "s" : ""})</span></strong>
-        <form hx-post="/api/translations/apply" hx-target="#toast-container" hx-swap="afterbegin"
+    <!-- Untranslated Transactions (primary -- action needed) -->
+    <div class="card mb-6 ${untranslated.length > 0 ? "ring-1 ring-amber-200 dark:ring-amber-800/50" : ""}">
+      <div class="card-header ${untranslated.length > 0 ? "!bg-amber-50/60 dark:!bg-amber-900/10 !border-b-amber-200/70 dark:!border-b-amber-800/40" : ""}">
+        <div class="flex items-center gap-2.5">
+          <div class="flex items-center justify-center w-7 h-7 rounded-lg ${untranslated.length > 0 ? "bg-amber-100 dark:bg-amber-900/30" : "bg-emerald-100 dark:bg-emerald-900/30"}">
+            ${untranslated.length > 0
+              ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-600 dark:text-amber-400"><path d="M12 9v2m0 4h.01M5.07 19H18.93a2 2 0 0 0 1.73-3L13.73 4a2 2 0 0 0-3.46 0L3.34 16a2 2 0 0 0 1.73 3z"/></svg>`
+              : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-600 dark:text-emerald-400"><polyline points="20 6 9 17 4 12"/></svg>`
+            }
+          </div>
+          <span class="font-semibold text-sm text-zinc-900 dark:text-white">Untranslated</span>
+          ${untranslated.length > 0
+            ? `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">${untranslated.length} need${untranslated.length !== 1 ? "" : "s"} attention</span>`
+            : `<span class="text-emerald-600 dark:text-emerald-400 text-xs font-medium">All done</span>`
+          }
+        </div>
+        ${untranslated.length > 0 ? `<form hx-post="/api/translations/apply" hx-target="#toast-container" hx-swap="afterbegin"
           hx-on::after-request="if(event.detail.successful) htmx.ajax('GET','/api/translations/untranslated','#untranslated-list')"
-          style="margin:0;">
-          <button type="submit" class="outline" hx-disabled-elt="this" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Apply All Rules</button>
-        </form>
-      </header>
+          class="m-0">
+          <button type="submit" class="btn btn-outline btn-sm" hx-disabled-elt="this">Apply All Rules</button>
+        </form>` : ""}
+      </div>
       ${untranslatedList()}
-    </article>
+    </div>
 
     <!-- Translation Rules (collapsible) -->
-    <article>
+    <div class="card mb-6">
       <details${rules.length === 0 ? " open" : ""}>
-        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
-          Translation Rules <span class="text-muted" style="font-weight:400;">(${rules.length})</span>
+        <summary class="flex items-center justify-between px-5 py-3 cursor-pointer select-none hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors list-none [&::-webkit-details-marker]:hidden">
+          <div class="flex items-center gap-2.5">
+            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 dark:bg-indigo-900/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-600 dark:text-indigo-400"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            </div>
+            <span class="font-semibold text-sm text-zinc-900 dark:text-white">Translation Rules</span>
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded-md text-xs font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 tabular-nums">${rules.length}</span>
+          </div>
+          <svg class="w-4 h-4 text-zinc-400 transition-transform [[open]>&]:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
         </summary>
-        <div style="padding:0 1.25rem 1rem;">
-          <table role="grid" class="card-table">
-            <thead>
-              <tr>
-                <th>English Name</th>
-                <th>Match Pattern (Hebrew)</th>
-                <th>Created</th>
-                <th></th>
-              </tr>
-            </thead>
-            ${translationRulesTableBody(rules)}
-          </table>
+        <div class="px-5 pb-4">
+          <div class="overflow-x-auto">
+            <table class="w-full text-left">
+              <thead>
+                <tr class="border-b border-zinc-200 dark:border-zinc-700">
+                  <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-3">English Name</th>
+                  <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-3">Match Pattern (Hebrew)</th>
+                  <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-3">Created</th>
+                  <th class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 px-4 py-3"></th>
+                </tr>
+              </thead>
+              ${translationRulesTableBody(rules)}
+            </table>
+          </div>
 
-          <details style="margin-top:1rem;">
-            <summary role="button" class="outline" style="text-align:center;">+ Add Rule</summary>
-            <form hx-post="/api/translations/rules" hx-target="#translation-rules-tbody" hx-swap="outerHTML"
+          <details class="mt-4">
+            <summary class="btn btn-outline text-center w-full cursor-pointer">+ Add Rule</summary>
+            <form class="mt-3 space-y-3" hx-post="/api/translations/rules" hx-target="#translation-rules-tbody" hx-swap="outerHTML"
               hx-on::after-request="if(event.detail.successful) this.reset()">
-              <div class="grid">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <label>
                   English Name
                   <input type="text" name="englishName" required placeholder="e.g. Shufersal">
@@ -58,27 +79,34 @@ export function translationsPage(): string {
                   <input type="text" name="matchPattern" required placeholder="e.g. &#1513;&#1493;&#1508;&#1512;&#1505;&#1500;" dir="rtl">
                 </label>
               </div>
-              <button type="submit" hx-disabled-elt="this">Add Rule</button>
+              <button type="submit" class="btn btn-primary" hx-disabled-elt="this">Add Rule</button>
             </form>
           </details>
         </div>
       </details>
-    </article>
+    </div>
 
     <!-- Already Translated (collapsible) -->
-    <article>
+    <div class="card">
       <details${translated.length > 0 && untranslated.length === 0 ? " open" : ""}>
-        <summary style="padding:0.85rem 1.25rem;cursor:pointer;font-weight:600;font-size:0.95rem;">
-          Translated <span class="text-muted" style="font-weight:400;">(${translated.length} merchant name${translated.length !== 1 ? "s" : ""})</span>
+        <summary class="flex items-center justify-between px-5 py-3 cursor-pointer select-none hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors list-none [&::-webkit-details-marker]:hidden">
+          <div class="flex items-center gap-2.5">
+            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-emerald-50 dark:bg-emerald-900/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-600 dark:text-emerald-400"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+            <span class="font-semibold text-sm text-zinc-900 dark:text-white">Translated</span>
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded-md text-xs font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 tabular-nums">${translated.length}</span>
+          </div>
+          <svg class="w-4 h-4 text-zinc-400 transition-transform [[open]>&]:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
         </summary>
-        <div style="padding:0 1.25rem 1rem;">
+        <div class="px-4 py-3">
           <input type="search" id="translate-filter" placeholder="Filter by name..."
-            style="margin:0 0 0.75rem;padding:0.4rem 0.75rem;font-size:0.85rem;"
+            class="mb-2 text-sm"
             oninput="filterTranslated(this.value)">
           ${translatedList()}
         </div>
       </details>
-    </article>
+    </div>
 
     <script>
       function filterTranslated(query) {

--- a/src/web/partials/category-rules-table.ts
+++ b/src/web/partials/category-rules-table.ts
@@ -1,0 +1,71 @@
+// Category rules table body partial — returned on add/delete for HTMX swap.
+
+import { escapeHtml } from "../layout.js";
+import type { CategoryRule } from "../../types/index.js";
+
+export function categoryRulesTableBody(rules: CategoryRule[]): string {
+  if (rules.length === 0) {
+    return `<tbody id="category-rules-tbody"><tr><td colspan="4">
+      <div class="empty-state">
+        <span class="empty-icon">&#128203;</span>
+        <p>No rules defined yet</p>
+        <p class="text-muted">Rules automatically classify your transactions by matching description and memo patterns.</p>
+      </div>
+    </td></tr></tbody>`;
+  }
+
+  const rowsHtml = rules
+    .map((r) => {
+      return `<tr>
+        <td data-label="Category">${escapeHtml(r.category)}</td>
+        <td data-label="Conditions">${formatConditions(r.conditions)}</td>
+        <td data-label="Priority">${r.priority}</td>
+        <td data-label="" class="actions">
+          <button hx-delete="/api/categories/rules/${r.id}" hx-target="#category-rules-tbody" hx-swap="outerHTML" hx-confirm="Delete this rule?" class="outline secondary" title="Delete rule">&#10005;</button>
+        </td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<tbody id="category-rules-tbody">${rowsHtml}</tbody>`;
+}
+
+function formatConditions(cond: unknown): string {
+  const conditions = cond as Record<string, unknown>;
+  const parts: string[] = [];
+
+  const desc = conditions.description as { pattern?: string; mode?: string } | undefined;
+  if (desc?.pattern) {
+    const modeSymbol = desc.mode === "exact" ? "=" : desc.mode === "regex" ? "~r" : "~";
+    parts.push(`description ${modeSymbol} "${escapeHtml(desc.pattern)}"`);
+  }
+
+  const memo = conditions.memo as { pattern?: string; mode?: string } | undefined;
+  if (memo?.pattern) {
+    const modeSymbol = memo.mode === "exact" ? "=" : memo.mode === "regex" ? "~r" : "~";
+    parts.push(`memo ${modeSymbol} "${escapeHtml(memo.pattern)}"`);
+  }
+
+  const account = conditions.account as string | undefined;
+  if (account) {
+    parts.push(`account = "${escapeHtml(account)}"`);
+  }
+
+  const amount = conditions.amount as { min?: number; max?: number; exact?: number } | undefined;
+  if (amount) {
+    if (amount.exact != null) parts.push(`amount = ${amount.exact}`);
+    else {
+      if (amount.min != null) parts.push(`amount >= ${amount.min}`);
+      if (amount.max != null) parts.push(`amount <= ${amount.max}`);
+    }
+  }
+
+  const direction = conditions.direction as string | undefined;
+  if (direction) {
+    parts.push(`direction = ${direction}`);
+  }
+
+  if (parts.length === 0) return `<span class="text-muted">No conditions</span>`;
+
+  return parts.map((p) => `<span class="condition-tag">${p}</span>`).join(" ");
+}

--- a/src/web/partials/category-rules-table.ts
+++ b/src/web/partials/category-rules-table.ts
@@ -1,4 +1,4 @@
-// Category rules table body partial — returned on add/delete for HTMX swap.
+// Category rules table body partial -- returned on add/delete for HTMX swap.
 
 import { escapeHtml } from "../layout.js";
 import type { CategoryRule } from "../../types/index.js";
@@ -6,22 +6,29 @@ import type { CategoryRule } from "../../types/index.js";
 export function categoryRulesTableBody(rules: CategoryRule[]): string {
   if (rules.length === 0) {
     return `<tbody id="category-rules-tbody"><tr><td colspan="4">
-      <div class="empty-state">
-        <span class="empty-icon">&#128203;</span>
-        <p>No rules defined yet</p>
-        <p class="text-muted">Rules automatically classify your transactions by matching description and memo patterns.</p>
+      <div class="flex flex-col items-center gap-2 py-12 text-center">
+        <span class="text-4xl">&#128203;</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">No rules defined yet</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm">Rules automatically classify your transactions by matching description and memo patterns.</p>
       </div>
     </td></tr></tbody>`;
   }
 
   const rowsHtml = rules
     .map((r) => {
-      return `<tr>
-        <td data-label="Category">${escapeHtml(r.category)}</td>
-        <td data-label="Conditions">${formatConditions(r.conditions)}</td>
-        <td data-label="Priority">${r.priority}</td>
-        <td data-label="" class="actions">
-          <button hx-delete="/api/categories/rules/${r.id}" hx-target="#category-rules-tbody" hx-swap="outerHTML" hx-confirm="Delete this rule?" class="outline secondary" title="Delete rule">&#10005;</button>
+      return `<tr class="border-b border-zinc-200 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+        <td class="px-4 py-3 text-sm"><span class="font-medium text-zinc-900 dark:text-zinc-100">${escapeHtml(r.category)}</span></td>
+        <td class="px-4 py-3 text-sm">${formatConditions(r.conditions)}</td>
+        <td class="px-4 py-3 text-sm text-right tabular-nums text-zinc-700 dark:text-zinc-300">${r.priority}</td>
+        <td class="px-4 py-3 text-sm text-right">
+          <button class="btn btn-ghost btn-ghost-danger"
+            hx-delete="/api/categories/rules/${r.id}"
+            hx-target="#category-rules-tbody"
+            hx-swap="outerHTML"
+            hx-confirm="Delete this rule?"
+            title="Delete rule">
+            &#10005; Delete
+          </button>
         </td>
       </tr>`;
     })
@@ -65,7 +72,7 @@ function formatConditions(cond: unknown): string {
     parts.push(`direction = ${direction}`);
   }
 
-  if (parts.length === 0) return `<span class="text-muted">No conditions</span>`;
+  if (parts.length === 0) return `<span class="text-zinc-500 dark:text-zinc-300 text-sm">No conditions</span>`;
 
-  return parts.map((p) => `<span class="condition-tag">${p}</span>`).join(" ");
+  return parts.map((p) => `<span class="inline-block px-2 py-0.5 text-xs font-mono bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800 rounded">${p}</span>`).join(" ");
 }

--- a/src/web/partials/category-sidebar.ts
+++ b/src/web/partials/category-sidebar.ts
@@ -1,4 +1,4 @@
-// Category sidebar partial — clickable list with counts.
+// Category sidebar partial -- clickable list with counts.
 
 import { escapeHtml } from "../layout.js";
 import { listCategories } from "../../db/repositories/categories.js";
@@ -7,8 +7,8 @@ export function categorySidebar(activeCategory?: string): string {
   const categories = listCategories();
 
   if (categories.length === 0) {
-    return `<div id="category-sidebar" class="category-sidebar">
-      <p class="text-muted" style="padding:0.75rem;">No transactions yet. Sync your providers first.</p>
+    return `<div id="category-sidebar" class="py-4 px-3">
+      <p class="text-zinc-500 dark:text-zinc-300 text-sm">No transactions yet. Sync your providers first.</p>
     </div>`;
   }
 
@@ -23,27 +23,38 @@ export function categorySidebar(activeCategory?: string): string {
     .map((c) => {
       const isActive = c.category === active;
       const isUncat = c.category === "Uncategorized";
-      const classes = ["category-item"];
-      if (isActive) classes.push("active");
-      if (isUncat) classes.push("uncategorized");
+
+      // Build class list for the sidebar item
+      const baseClasses = "category-item flex items-center justify-between px-3 py-2 text-sm border-l-[3px] transition-colors cursor-pointer no-underline";
+      const hoverClasses = "hover:bg-zinc-100 dark:hover:bg-zinc-800/50";
+      let stateClasses: string;
+      if (isActive && isUncat) {
+        stateClasses = "bg-amber-50 dark:bg-amber-900/20 border-l-amber-500 font-semibold text-zinc-900 dark:text-white";
+      } else if (isActive) {
+        stateClasses = "bg-indigo-50 dark:bg-indigo-900/20 border-l-indigo-600 font-semibold text-zinc-900 dark:text-white";
+      } else if (isUncat) {
+        stateClasses = "border-l-amber-400/50 text-zinc-700 dark:text-zinc-300";
+      } else {
+        stateClasses = "border-l-transparent text-zinc-700 dark:text-zinc-300";
+      }
 
       const encodedCat = encodeURIComponent(c.category);
       return `<li>
-        <a class="${classes.join(" ")}"
+        <a class="${baseClasses} ${hoverClasses} ${stateClasses}"
           href="/categories?cat=${encodedCat}"
           hx-get="/api/categories/transactions?cat=${encodedCat}"
           hx-target="#tx-panel"
           hx-swap="innerHTML"
           hx-push-url="/categories?cat=${encodedCat}"
           hx-on::after-request="document.querySelectorAll('.category-item').forEach(function(el){el.classList.remove('active')});this.classList.add('active')">
-          <span>${escapeHtml(c.category)}</span>
-          <span class="cat-count">${c.transactionCount}</span>
+          <span class="truncate">${escapeHtml(c.category)}</span>
+          <span class="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 text-xs font-semibold rounded-full bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 tabular-nums">${c.transactionCount}</span>
         </a>
       </li>`;
     })
     .join("\n");
 
-  return `<div id="category-sidebar" class="category-sidebar">
-    <ul class="category-list">${items}</ul>
+  return `<div id="category-sidebar" class="py-2 overflow-y-auto max-h-[32rem] scrollbar-hide">
+    <ul class="flex flex-col">${items}</ul>
   </div>`;
 }

--- a/src/web/partials/category-sidebar.ts
+++ b/src/web/partials/category-sidebar.ts
@@ -1,0 +1,49 @@
+// Category sidebar partial — clickable list with counts.
+
+import { escapeHtml } from "../layout.js";
+import { listCategories } from "../../db/repositories/categories.js";
+
+export function categorySidebar(activeCategory?: string): string {
+  const categories = listCategories();
+
+  if (categories.length === 0) {
+    return `<div id="category-sidebar" class="category-sidebar">
+      <p class="text-muted" style="padding:0.75rem;">No transactions yet. Sync your providers first.</p>
+    </div>`;
+  }
+
+  // Pin Uncategorized to top
+  const uncategorized = categories.find((c) => c.category === "Uncategorized");
+  const rest = categories.filter((c) => c.category !== "Uncategorized");
+
+  const sorted = uncategorized ? [uncategorized, ...rest] : rest;
+  const active = activeCategory ?? (uncategorized && uncategorized.transactionCount > 0 ? "Uncategorized" : sorted[0]?.category);
+
+  const items = sorted
+    .map((c) => {
+      const isActive = c.category === active;
+      const isUncat = c.category === "Uncategorized";
+      const classes = ["category-item"];
+      if (isActive) classes.push("active");
+      if (isUncat) classes.push("uncategorized");
+
+      const encodedCat = encodeURIComponent(c.category);
+      return `<li>
+        <a class="${classes.join(" ")}"
+          href="/categories?cat=${encodedCat}"
+          hx-get="/api/categories/transactions?cat=${encodedCat}"
+          hx-target="#tx-panel"
+          hx-swap="innerHTML"
+          hx-push-url="/categories?cat=${encodedCat}"
+          hx-on::after-request="document.querySelectorAll('.category-item').forEach(function(el){el.classList.remove('active')});this.classList.add('active')">
+          <span>${escapeHtml(c.category)}</span>
+          <span class="cat-count">${c.transactionCount}</span>
+        </a>
+      </li>`;
+    })
+    .join("\n");
+
+  return `<div id="category-sidebar" class="category-sidebar">
+    <ul class="category-list">${items}</ul>
+  </div>`;
+}

--- a/src/web/partials/category-summary-table.ts
+++ b/src/web/partials/category-summary-table.ts
@@ -1,0 +1,49 @@
+// Category summary table partial — swappable tbody with rename/delete actions.
+
+import { escapeHtml } from "../layout.js";
+import { listCategoriesWithSource } from "../../db/repositories/categories.js";
+
+export function categorySummaryTable(): string {
+  const categories = listCategoriesWithSource();
+
+  if (categories.length === 0) {
+    return `<tbody id="category-summary-tbody"><tr><td colspan="5">
+      <div class="empty-state">
+        <span class="empty-icon">&#128203;</span>
+        <p>No categories yet</p>
+        <p class="text-muted">Sync your providers to see transaction categories.</p>
+      </div>
+    </td></tr></tbody>`;
+  }
+
+  const rows = categories
+    .map((c) => {
+      const isProtected = c.category === "Uncategorized";
+      const encodedName = encodeURIComponent(c.category);
+      const actions = isProtected
+        ? `<span class="text-muted" style="font-size:0.78rem;">System</span>`
+        : `<div class="actions">
+            <button hx-get="/api/categories/${encodedName}/edit" hx-target="#cat-name-${cssId(c.category)}" hx-swap="innerHTML" class="outline secondary" title="Rename">&#9998;</button>
+            <button hx-get="/api/categories/${encodedName}/delete-confirm" hx-target="#category-action-panel" hx-swap="innerHTML" class="outline secondary" title="Delete">&#10005;</button>
+          </div>`;
+
+      const sourceLabel = c.source === "both" ? "both" : c.source === "rules" ? "rules only" : "transactions";
+      const totalFormatted = c.totalAmount.toLocaleString("he-IL", { style: "currency", currency: "ILS", minimumFractionDigits: 0 });
+
+      return `<tr>
+        <td data-label="Category" id="cat-name-${cssId(c.category)}">${escapeHtml(c.category)}</td>
+        <td data-label="Transactions">${c.transactionCount}</td>
+        <td data-label="Total">${totalFormatted}</td>
+        <td data-label="Source"><span class="text-muted">${sourceLabel}</span></td>
+        <td data-label="">${actions}</td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<tbody id="category-summary-tbody">${rows}</tbody>`;
+}
+
+// Generate a CSS-safe id from a category name
+function cssId(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, "-").toLowerCase();
+}

--- a/src/web/partials/category-summary-table.ts
+++ b/src/web/partials/category-summary-table.ts
@@ -1,4 +1,5 @@
-// Category summary table partial — swappable tbody with rename/delete actions.
+// Category summary table partial -- swappable tbody with rename/delete actions.
+// Percentage bar for tx distribution using Tailwind utility classes.
 
 import { escapeHtml } from "../layout.js";
 import { listCategoriesWithSource } from "../../db/repositories/categories.js";
@@ -7,35 +8,64 @@ export function categorySummaryTable(): string {
   const categories = listCategoriesWithSource();
 
   if (categories.length === 0) {
-    return `<tbody id="category-summary-tbody"><tr><td colspan="5">
-      <div class="empty-state">
-        <span class="empty-icon">&#128203;</span>
-        <p>No categories yet</p>
-        <p class="text-muted">Sync your providers to see transaction categories.</p>
+    return `<tbody id="category-summary-tbody"><tr><td colspan="4">
+      <div class="flex flex-col items-center gap-2 py-12 text-center">
+        <span class="text-4xl">&#128203;</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">No categories yet</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm">Sync your providers to see transaction categories.</p>
       </div>
     </td></tr></tbody>`;
   }
+
+  // Calculate total transactions for percentage bar
+  const totalTx = categories.reduce((sum, c) => sum + c.transactionCount, 0);
 
   const rows = categories
     .map((c) => {
       const isProtected = c.category === "Uncategorized";
       const encodedName = encodeURIComponent(c.category);
       const actions = isProtected
-        ? `<span class="text-muted" style="font-size:0.78rem;">System</span>`
-        : `<div class="actions">
-            <button hx-get="/api/categories/${encodedName}/edit" hx-target="#cat-name-${cssId(c.category)}" hx-swap="innerHTML" class="outline secondary" title="Rename">&#9998;</button>
-            <button hx-get="/api/categories/${encodedName}/delete-confirm" hx-target="#category-action-panel" hx-swap="innerHTML" class="outline secondary" title="Delete">&#10005;</button>
+        ? `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">System</span>`
+        : `<div class="flex items-center gap-1">
+            <button class="btn btn-ghost"
+              hx-get="/api/categories/${encodedName}/edit"
+              hx-target="#cat-name-${cssId(c.category)}"
+              hx-swap="innerHTML"
+              title="Rename category">
+              &#9998; Rename
+            </button>
+            <button class="btn btn-ghost btn-ghost-danger"
+              hx-get="/api/categories/${encodedName}/delete-confirm"
+              hx-target="#category-action-panel"
+              hx-swap="innerHTML"
+              title="Delete category">
+              &#10005; Delete
+            </button>
           </div>`;
 
-      const sourceLabel = c.source === "both" ? "both" : c.source === "rules" ? "rules only" : "transactions";
-      const totalFormatted = c.totalAmount.toLocaleString("he-IL", { style: "currency", currency: "ILS", minimumFractionDigits: 0 });
+      const totalFormatted = c.totalAmount.toLocaleString("he-IL", {
+        style: "currency",
+        currency: "ILS",
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      });
 
-      return `<tr>
-        <td data-label="Category" id="cat-name-${cssId(c.category)}">${escapeHtml(c.category)}</td>
-        <td data-label="Transactions">${c.transactionCount}</td>
-        <td data-label="Total">${totalFormatted}</td>
-        <td data-label="Source"><span class="text-muted">${sourceLabel}</span></td>
-        <td data-label="">${actions}</td>
+      // Percentage of transactions in this category
+      const pct = totalTx > 0 ? Math.round((c.transactionCount / totalTx) * 100) : 0;
+
+      return `<tr class="border-b border-zinc-200 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+        <td class="px-4 py-3 text-sm" id="cat-name-${cssId(c.category)}">
+          <span class="font-medium text-zinc-900 dark:text-zinc-100">${escapeHtml(c.category)}</span>
+        </td>
+        <td class="px-4 py-3 text-sm">
+          <div class="flex items-center gap-2">
+            <span class="tabular-nums text-zinc-700 dark:text-zinc-300">${c.transactionCount}</span>
+            <span class="inline-block w-16 h-1 rounded-full bg-zinc-200 dark:bg-zinc-700"><span class="inline-block h-1 rounded-full bg-indigo-500" style="width:${pct}%"></span></span>
+            <span class="text-xs text-zinc-400 dark:text-zinc-400 tabular-nums">${pct}%</span>
+          </div>
+        </td>
+        <td class="px-4 py-3 text-sm text-right tabular-nums font-medium text-zinc-700 dark:text-zinc-300">${totalFormatted}</td>
+        <td class="px-4 py-3 text-sm text-right">${actions}</td>
       </tr>`;
     })
     .join("\n");

--- a/src/web/partials/category-tx-panel.ts
+++ b/src/web/partials/category-tx-panel.ts
@@ -1,0 +1,90 @@
+// Transaction panel partial — shows transactions for a category with inline category dropdowns.
+
+import { escapeHtml } from "../layout.js";
+import { listTransactions } from "../../db/repositories/transactions.js";
+import { listAllCategories } from "../../db/repositories/categories.js";
+import type { TransactionWithContext } from "../../types/index.js";
+
+export function categoryTxPanel(category: string): string {
+  const isUncat = category === "Uncategorized";
+  const txs = listTransactions({
+    category: isUncat ? null : category,
+    sort: "date",
+    sortDirection: "desc",
+  });
+
+  const allCategories = listAllCategories();
+
+  if (txs.length === 0) {
+    const message = isUncat
+      ? "All transactions are categorized!"
+      : `No transactions in "${escapeHtml(category)}"`;
+    const icon = isUncat ? "&#10003;" : "&#128203;";
+    const subtext = isUncat
+      ? "Every transaction has been assigned a category."
+      : "Transactions moved to other categories will disappear from here.";
+    return `<div id="tx-panel">
+      <div class="empty-state">
+        <span class="empty-icon">${icon}</span>
+        <p>${message}</p>
+        <p class="text-muted">${subtext}</p>
+      </div>
+    </div>`;
+  }
+
+  const header = `<div style="display:flex;justify-content:space-between;align-items:center;padding:0.75rem 1rem;border-bottom:1px solid var(--pico-muted-border-color);">
+    <strong>${escapeHtml(category)} <span class="text-muted" style="font-weight:400;">(${txs.length})</span></strong>
+  </div>`;
+
+  const rows = txs.map((tx) => txRow(tx, category, allCategories)).join("\n");
+
+  return `<div id="tx-panel">${header}${rows}</div>`;
+}
+
+function txRow(tx: TransactionWithContext, currentCategory: string, allCategories: string[]): string {
+  const date = formatDate(tx.date);
+  const amount = tx.chargedAmount;
+  const amountClass = amount < 0 ? "tx-amount-expense" : "tx-amount-income";
+  const amountStr = formatAmount(amount);
+  const hebrewDesc = escapeHtml(tx.description);
+  const englishDesc = tx.descriptionEn ? escapeHtml(tx.descriptionEn) : "";
+
+  const catOptions = allCategories
+    .map((c) => {
+      const selected = c === (tx.category || "Uncategorized") ? " selected" : "";
+      return `<option value="${escapeHtml(c)}"${selected}>${escapeHtml(c)}</option>`;
+    })
+    .join("");
+
+  return `<div class="tx-row" id="tx-row-${tx.id}">
+    <div class="tx-date">${date}</div>
+    <div class="tx-desc">
+      <span class="tx-desc-he" dir="rtl" lang="he">${hebrewDesc}</span>
+      ${englishDesc ? `<span class="tx-desc-en">${englishDesc}</span>` : ""}
+    </div>
+    <div class="tx-amount ${amountClass}">${amountStr}</div>
+    <select class="inline-select"
+      hx-patch="/api/transactions/${tx.id}/category"
+      hx-vals='{"from": "${escapeHtml(currentCategory)}"}'
+      hx-target="#tx-row-${tx.id}"
+      hx-swap="outerHTML"
+      name="category">
+      ${catOptions}
+    </select>
+  </div>`;
+}
+
+function formatDate(isoString: string): string {
+  const d = new Date(isoString);
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${day}/${month}`;
+}
+
+function formatAmount(amount: number): string {
+  return amount.toLocaleString("he-IL", {
+    style: "currency",
+    currency: "ILS",
+    minimumFractionDigits: 2,
+  });
+}

--- a/src/web/partials/category-tx-panel.ts
+++ b/src/web/partials/category-tx-panel.ts
@@ -1,4 +1,4 @@
-// Transaction panel partial — shows transactions for a category with inline category dropdowns.
+// Transaction panel partial -- shows transactions for a category with inline category dropdowns.
 
 import { escapeHtml } from "../layout.js";
 import { listTransactions } from "../../db/repositories/transactions.js";
@@ -24,27 +24,30 @@ export function categoryTxPanel(category: string): string {
       ? "Every transaction has been assigned a category."
       : "Transactions moved to other categories will disappear from here.";
     return `<div id="tx-panel">
-      <div class="empty-state">
-        <span class="empty-icon">${icon}</span>
-        <p>${message}</p>
-        <p class="text-muted">${subtext}</p>
+      <div class="flex flex-col items-center gap-2 py-12 text-center">
+        <span class="text-4xl">${icon}</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">${message}</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm">${subtext}</p>
       </div>
     </div>`;
   }
 
-  const header = `<div style="display:flex;justify-content:space-between;align-items:center;padding:0.75rem 1rem;border-bottom:1px solid var(--pico-muted-border-color);">
-    <strong>${escapeHtml(category)} <span class="text-muted" style="font-weight:400;">(${txs.length})</span></strong>
+  const header = `<div class="px-4 py-2.5 border-b border-zinc-200 dark:border-zinc-800">
+    <span class="font-semibold text-sm text-zinc-900 dark:text-white">${escapeHtml(category)} <span class="text-zinc-500 dark:text-zinc-300 font-normal">(${txs.length})</span></span>
   </div>`;
 
   const rows = txs.map((tx) => txRow(tx, category, allCategories)).join("\n");
 
-  return `<div id="tx-panel">${header}${rows}</div>`;
+  return `<div id="tx-panel" class="overflow-y-auto max-h-[32rem] scrollbar-hide">${header}${rows}</div>`;
 }
 
 function txRow(tx: TransactionWithContext, currentCategory: string, allCategories: string[]): string {
   const date = formatDate(tx.date);
   const amount = tx.chargedAmount;
-  const amountClass = amount < 0 ? "tx-amount-expense" : "tx-amount-income";
+  const isExpense = amount < 0;
+  const amountColor = isExpense
+    ? "text-rose-600 dark:text-rose-400"
+    : "text-emerald-600 dark:text-emerald-400";
   const amountStr = formatAmount(amount);
   const hebrewDesc = escapeHtml(tx.description);
   const englishDesc = tx.descriptionEn ? escapeHtml(tx.descriptionEn) : "";
@@ -56,14 +59,14 @@ function txRow(tx: TransactionWithContext, currentCategory: string, allCategorie
     })
     .join("");
 
-  return `<div class="tx-row" id="tx-row-${tx.id}">
-    <div class="tx-date">${date}</div>
-    <div class="tx-desc">
-      <span class="tx-desc-he" dir="rtl" lang="he">${hebrewDesc}</span>
-      ${englishDesc ? `<span class="tx-desc-en">${englishDesc}</span>` : ""}
+  return `<div class="tx-row grid grid-cols-[4rem_1fr_auto_auto] gap-3 items-center px-4 py-2.5 border-b border-zinc-200 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors" id="tx-row-${tx.id}">
+    <div class="text-xs text-zinc-500 dark:text-zinc-300 tabular-nums">${date}</div>
+    <div class="min-w-0">
+      <span class="block text-sm text-zinc-900 dark:text-zinc-100 truncate" dir="rtl" lang="he" style="unicode-bidi:isolate">${hebrewDesc}</span>
+      ${englishDesc ? `<span class="block text-xs text-zinc-500 dark:text-zinc-300 truncate">${englishDesc}</span>` : ""}
     </div>
-    <div class="tx-amount ${amountClass}">${amountStr}</div>
-    <select class="inline-select"
+    <div class="font-semibold tabular-nums text-sm ${amountColor} text-right whitespace-nowrap">${amountStr}</div>
+    <select class="!w-auto !py-1 !px-2 !text-xs"
       hx-patch="/api/transactions/${tx.id}/category"
       hx-vals='{"from": "${escapeHtml(currentCategory)}"}'
       hx-target="#tx-row-${tx.id}"
@@ -82,9 +85,12 @@ function formatDate(isoString: string): string {
 }
 
 function formatAmount(amount: number): string {
+  // Use 0 decimal places for amounts >= 10, 2 for smaller amounts (sub-shekel precision)
+  const fracDigits = Math.abs(amount) >= 10 ? 0 : 2;
   return amount.toLocaleString("he-IL", {
     style: "currency",
     currency: "ILS",
-    minimumFractionDigits: 2,
+    minimumFractionDigits: fracDigits,
+    maximumFractionDigits: fracDigits,
   });
 }

--- a/src/web/partials/provider-cards.ts
+++ b/src/web/partials/provider-cards.ts
@@ -1,0 +1,73 @@
+// Provider card list partial — returned on add/delete for HTMX swap.
+
+import { escapeHtml } from "../layout.js";
+import type { Provider } from "../../types/index.js";
+
+
+export interface ProviderCardData {
+  provider: Provider;
+  hasAuth: boolean;
+  txCount: number;
+}
+
+export function providerCards(cards: ProviderCardData[]): string {
+  if (cards.length === 0) {
+    return `<div id="provider-cards">
+      <div class="empty-state">
+        <span class="empty-icon">&#127974;</span>
+        <p>No providers configured yet</p>
+        <p class="text-muted">Connect a bank or credit card account to start tracking your finances.</p>
+      </div>
+    </div>`;
+  }
+
+  const html = cards
+    .map((c) => {
+      const p = c.provider;
+      const typeLabel = p.type === "bank" ? "Bank" : "Credit Card";
+      const typeIcon = p.type === "bank" ? "&#127974;" : "&#128179;";
+      const syncDisplay = p.lastSyncedAt ? formatRelativeTime(p.lastSyncedAt) : "Never synced";
+      const authBadge = c.hasAuth
+        ? `<span class="badge badge-success">&#10003; Connected</span>`
+        : `<span class="badge badge-warning">&#9888; Setup needed</span>`;
+
+      return `<div class="provider-card" id="provider-card-${p.id}">
+        <div class="provider-card-info">
+          <div class="provider-card-name">${typeIcon} ${escapeHtml(p.displayName)}</div>
+          <div class="provider-card-meta">
+            <span>${escapeHtml(p.alias)}</span>
+            <span class="separator">&middot;</span>
+            <span>${typeLabel}</span>
+            <span class="separator">&middot;</span>
+            <span>${c.txCount} transaction${c.txCount !== 1 ? "s" : ""}</span>
+            <span class="separator">&middot;</span>
+            <span>${syncDisplay}</span>
+          </div>
+          <div style="margin-top:0.3rem">${authBadge}</div>
+        </div>
+        <div class="provider-card-actions">
+          <button hx-get="/api/providers/${p.id}/auth-form" hx-target="#auth-form-container" hx-swap="innerHTML" class="outline secondary" title="Update credentials">&#9998;</button>
+          <button hx-delete="/api/providers/${p.id}" hx-target="#provider-cards" hx-swap="outerHTML" hx-confirm="Remove ${escapeHtml(p.displayName)} and its credentials?" class="outline secondary" title="Remove provider">&#10005;</button>
+        </div>
+      </div>`;
+    })
+    .join("\n");
+
+  return `<div id="provider-cards">${html}</div>`;
+}
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString("en-IL");
+}

--- a/src/web/partials/provider-cards.ts
+++ b/src/web/partials/provider-cards.ts
@@ -1,4 +1,4 @@
-// Provider card list partial — returned on add/delete for HTMX swap.
+// Provider card list partial -- returned on add/delete for HTMX swap.
 
 import { escapeHtml } from "../layout.js";
 import type { Provider } from "../../types/index.js";
@@ -13,41 +13,58 @@ export interface ProviderCardData {
 export function providerCards(cards: ProviderCardData[]): string {
   if (cards.length === 0) {
     return `<div id="provider-cards">
-      <div class="empty-state">
-        <span class="empty-icon">&#127974;</span>
-        <p>No providers configured yet</p>
-        <p class="text-muted">Connect a bank or credit card account to start tracking your finances.</p>
+      <div class="flex flex-col items-center gap-3 py-14 text-center">
+        <div class="flex items-center justify-center w-14 h-14 rounded-2xl bg-zinc-100 dark:bg-zinc-800 mb-1">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="text-zinc-400 dark:text-zinc-500"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+        </div>
+        <p class="text-zinc-800 dark:text-zinc-200 font-semibold">No providers yet</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm max-w-xs">Connect your first bank or credit card below to start tracking transactions automatically.</p>
       </div>
     </div>`;
   }
 
   const html = cards
-    .map((c) => {
+    .map((c, i) => {
       const p = c.provider;
       const typeLabel = p.type === "bank" ? "Bank" : "Credit Card";
       const typeIcon = p.type === "bank" ? "&#127974;" : "&#128179;";
       const syncDisplay = p.lastSyncedAt ? formatRelativeTime(p.lastSyncedAt) : "Never synced";
       const authBadge = c.hasAuth
-        ? `<span class="badge badge-success">&#10003; Connected</span>`
-        : `<span class="badge badge-warning">&#9888; Setup needed</span>`;
+        ? `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">&#10003; Connected</span>`
+        : `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">&#9888; Setup needed</span>`;
+      const isLast = i === cards.length - 1;
+      const borderClass = isLast ? "" : " border-b border-zinc-200 dark:border-zinc-700";
 
-      return `<div class="provider-card" id="provider-card-${p.id}">
-        <div class="provider-card-info">
-          <div class="provider-card-name">${typeIcon} ${escapeHtml(p.displayName)}</div>
-          <div class="provider-card-meta">
+      return `<div class="flex items-center justify-between px-5 py-4 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors${borderClass}" id="provider-card-${p.id}">
+        <div class="min-w-0">
+          <div class="font-semibold text-zinc-900 dark:text-white text-sm">${typeIcon} ${escapeHtml(p.displayName)}</div>
+          <div class="flex flex-wrap items-center gap-1.5 text-zinc-500 dark:text-zinc-300 text-xs mt-1">
             <span>${escapeHtml(p.alias)}</span>
-            <span class="separator">&middot;</span>
+            <span class="text-zinc-300 dark:text-zinc-500">&middot;</span>
             <span>${typeLabel}</span>
-            <span class="separator">&middot;</span>
+            <span class="text-zinc-300 dark:text-zinc-500">&middot;</span>
             <span>${c.txCount} transaction${c.txCount !== 1 ? "s" : ""}</span>
-            <span class="separator">&middot;</span>
+            <span class="text-zinc-300 dark:text-zinc-500">&middot;</span>
             <span>${syncDisplay}</span>
           </div>
-          <div style="margin-top:0.3rem">${authBadge}</div>
+          <div class="mt-1.5">${authBadge}</div>
         </div>
-        <div class="provider-card-actions">
-          <button hx-get="/api/providers/${p.id}/auth-form" hx-target="#auth-form-container" hx-swap="innerHTML" class="outline secondary" title="Update credentials">&#9998;</button>
-          <button hx-delete="/api/providers/${p.id}" hx-target="#provider-cards" hx-swap="outerHTML" hx-confirm="Remove ${escapeHtml(p.displayName)} and its credentials?" class="outline secondary" title="Remove provider">&#10005;</button>
+        <div class="flex items-center gap-1 shrink-0 ml-4">
+          <button class="btn btn-ghost"
+            hx-get="/api/providers/${p.id}/auth-form"
+            hx-target="#auth-form-container"
+            hx-swap="innerHTML"
+            title="Update credentials">
+            &#9998; Edit
+          </button>
+          <button class="btn btn-ghost btn-ghost-danger"
+            hx-delete="/api/providers/${p.id}"
+            hx-target="#provider-cards"
+            hx-swap="outerHTML"
+            hx-confirm="Remove ${escapeHtml(p.displayName)} and its credentials?"
+            title="Remove provider">
+            &#10005; Remove
+          </button>
         </div>
       </div>`;
     })

--- a/src/web/partials/provider-fields.ts
+++ b/src/web/partials/provider-fields.ts
@@ -1,0 +1,90 @@
+// Dynamic login fields partial — returned by GET /api/providers/fields/:companyId
+// Renders the correct input fields based on the provider's loginFields.
+
+import { PROVIDERS, isValidCompanyId } from "../../types/provider.js";
+import { getProvidersByCompanyId } from "../../db/repositories/providers.js";
+
+export function providerLoginFields(companyId: string): string {
+  if (!isValidCompanyId(companyId)) {
+    return `<p class="text-muted">Unknown provider.</p>`;
+  }
+
+  const info = PROVIDERS[companyId];
+  const existingInstances = getProvidersByCompanyId(companyId);
+
+  let aliasField = "";
+  if (existingInstances.length > 0) {
+    const existing = existingInstances.map((p) => p.alias).join(", ");
+    aliasField = `
+      <label>
+        Alias <small class="text-muted">(existing: ${existing})</small>
+        <input type="text" name="alias" required placeholder="e.g. leumi-joint" pattern="[a-zA-Z0-9_-]+">
+      </label>`;
+  }
+
+  const fields = info.loginFields
+    .map((field) => {
+      const isPassword = field === "password" || field === "otpLongTermToken";
+      const inputType = isPassword ? "password" : "text";
+      const required = field === "otpLongTermToken" ? "" : " required";
+      const placeholder = field === "otpLongTermToken" ? "Leave empty if not available" : "";
+      return `
+      <label>
+        ${fieldLabel(field)}
+        <input type="${inputType}" name="cred_${field}" autocomplete="off"${required}${placeholder ? ` placeholder="${placeholder}"` : ""}>
+      </label>`;
+    })
+    .join("\n");
+
+  return `${aliasField}${fields}
+    <input type="hidden" name="companyId" value="${companyId}">
+    <button type="submit" hx-disabled-elt="this">Add Provider</button>`;
+}
+
+export function providerAuthFields(companyId: string, providerId: number): string {
+  if (!isValidCompanyId(companyId)) {
+    return `<p class="text-muted">Unknown provider.</p>`;
+  }
+
+  const info = PROVIDERS[companyId];
+
+  const fields = info.loginFields
+    .map((field) => {
+      const isPassword = field === "password" || field === "otpLongTermToken";
+      const inputType = isPassword ? "password" : "text";
+      const required = field === "otpLongTermToken" ? "" : " required";
+      const placeholder = field === "otpLongTermToken" ? "Leave empty if not available" : "";
+      return `
+      <label>
+        ${fieldLabel(field)}
+        <input type="${inputType}" name="cred_${field}" autocomplete="off"${required}${placeholder ? ` placeholder="${placeholder}"` : ""}>
+      </label>`;
+    })
+    .join("\n");
+
+  return `<article>
+    <form hx-post="/api/providers/${providerId}/auth" hx-target="#auth-form-container" hx-swap="innerHTML">
+      <h4>Update Credentials</h4>
+      ${fields}
+      <div class="grid">
+        <button type="submit" hx-disabled-elt="this">Save</button>
+        <button type="button" class="secondary outline" onclick="document.getElementById('auth-form-container').innerHTML=''">Cancel</button>
+      </div>
+    </form>
+  </article>`;
+}
+
+function fieldLabel(field: string): string {
+  const labels: Record<string, string> = {
+    username: "Username",
+    userCode: "User Code",
+    password: "Password",
+    id: "ID Number",
+    num: "Branch/Account Number",
+    card6Digits: "Last 6 Digits of Card",
+    email: "Email",
+    nationalID: "National ID",
+    otpLongTermToken: "OTP Long-Term Token",
+  };
+  return labels[field] ?? field;
+}

--- a/src/web/partials/provider-fields.ts
+++ b/src/web/partials/provider-fields.ts
@@ -6,7 +6,7 @@ import { getProvidersByCompanyId } from "../../db/repositories/providers.js";
 
 export function providerLoginFields(companyId: string): string {
   if (!isValidCompanyId(companyId)) {
-    return `<p class="text-muted">Unknown provider.</p>`;
+    return `<p class="text-zinc-500 dark:text-zinc-300 text-sm">Unknown provider.</p>`;
   }
 
   const info = PROVIDERS[companyId];
@@ -17,7 +17,7 @@ export function providerLoginFields(companyId: string): string {
     const existing = existingInstances.map((p) => p.alias).join(", ");
     aliasField = `
       <label>
-        Alias <small class="text-muted">(existing: ${existing})</small>
+        Alias <span class="text-zinc-500 dark:text-zinc-300 text-xs font-normal">(existing: ${existing})</span>
         <input type="text" name="alias" required placeholder="e.g. leumi-joint" pattern="[a-zA-Z0-9_-]+">
       </label>`;
   }
@@ -38,12 +38,12 @@ export function providerLoginFields(companyId: string): string {
 
   return `${aliasField}${fields}
     <input type="hidden" name="companyId" value="${companyId}">
-    <button type="submit" hx-disabled-elt="this">Add Provider</button>`;
+    <button type="submit" class="btn btn-primary mt-2" hx-disabled-elt="this">Add Provider</button>`;
 }
 
 export function providerAuthFields(companyId: string, providerId: number): string {
   if (!isValidCompanyId(companyId)) {
-    return `<p class="text-muted">Unknown provider.</p>`;
+    return `<p class="text-zinc-500 dark:text-zinc-300 text-sm">Unknown provider.</p>`;
   }
 
   const info = PROVIDERS[companyId];
@@ -62,16 +62,16 @@ export function providerAuthFields(companyId: string, providerId: number): strin
     })
     .join("\n");
 
-  return `<article>
-    <form hx-post="/api/providers/${providerId}/auth" hx-target="#auth-form-container" hx-swap="innerHTML">
-      <h4>Update Credentials</h4>
+  return `<div class="card mt-4">
+    <form class="p-5" hx-post="/api/providers/${providerId}/auth" hx-target="#auth-form-container" hx-swap="innerHTML">
+      <h4 class="text-base font-semibold text-zinc-900 dark:text-white mb-4">Update Credentials</h4>
       ${fields}
-      <div class="grid">
-        <button type="submit" hx-disabled-elt="this">Save</button>
-        <button type="button" class="secondary outline" onclick="document.getElementById('auth-form-container').innerHTML=''">Cancel</button>
+      <div class="grid grid-cols-2 gap-4 mt-4">
+        <button type="submit" class="btn btn-primary" hx-disabled-elt="this">Save</button>
+        <button type="button" class="btn btn-outline" onclick="document.getElementById('auth-form-container').innerHTML=''">Cancel</button>
       </div>
     </form>
-  </article>`;
+  </div>`;
 }
 
 function fieldLabel(field: string): string {

--- a/src/web/partials/provider-table.ts
+++ b/src/web/partials/provider-table.ts
@@ -1,0 +1,62 @@
+// Provider table body partial — returned on add/delete for HTMX swap.
+
+import { escapeHtml } from "../layout.js";
+import type { Provider } from "../../types/index.js";
+
+export interface ProviderRow {
+  provider: Provider;
+  hasAuth: boolean;
+}
+
+export function providerTableBody(rows: ProviderRow[]): string {
+  if (rows.length === 0) {
+    return `<tbody id="provider-tbody"><tr><td colspan="6">
+      <div class="empty-state">
+        <span class="empty-icon">&#127974;</span>
+        <p>No providers configured yet</p>
+        <p class="text-muted">Connect a bank or credit card account to start tracking your finances.</p>
+      </div>
+    </td></tr></tbody>`;
+  }
+
+  const rowsHtml = rows
+    .map((r) => {
+      const p = r.provider;
+      const syncDisplay = p.lastSyncedAt ? formatRelativeTime(p.lastSyncedAt) : "Never";
+      const authBadge = r.hasAuth
+        ? `<span class="badge badge-success">&#10003; Connected</span>`
+        : `<span class="badge badge-danger">&#10007; Missing</span>`;
+      const typeLabel = p.type === "bank" ? "Bank" : "Credit Card";
+
+      return `<tr>
+        <td data-label="Alias">${escapeHtml(p.alias)}</td>
+        <td data-label="Name">${escapeHtml(p.displayName)}</td>
+        <td data-label="Type">${typeLabel}</td>
+        <td data-label="Last Synced">${syncDisplay}</td>
+        <td data-label="Auth">${authBadge}</td>
+        <td data-label="" class="actions">
+          <button hx-get="/api/providers/${p.id}/auth-form" hx-target="#auth-form-container" hx-swap="innerHTML" class="outline secondary" title="Update credentials">&#9998;</button>
+          <button hx-delete="/api/providers/${p.id}" hx-target="#provider-tbody" hx-swap="outerHTML" hx-confirm="Remove ${escapeHtml(p.displayName)} and its credentials?" class="outline secondary" title="Remove provider">&#10005;</button>
+        </td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<tbody id="provider-tbody">${rowsHtml}</tbody>`;
+}
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString("en-IL");
+}

--- a/src/web/partials/toast.ts
+++ b/src/web/partials/toast.ts
@@ -1,9 +1,9 @@
-// Toast notification partial — injected via hx-swap-oob into #toast-container
+// Toast notification partial -- injected via hx-swap-oob into #toast-container
 
 export function toastSuccess(message: string): string {
-  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast toast-success">${message}</div></div>`;
+  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast px-4 py-3 rounded-lg text-sm font-medium text-white shadow-lg backdrop-blur-sm bg-emerald-600/95">${message}</div></div>`;
 }
 
 export function toastError(message: string): string {
-  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast toast-error">${message}<button class="toast-close" title="Dismiss">&times;</button></div></div>`;
+  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast toast-error px-4 py-3 pr-9 rounded-lg text-sm font-medium text-white shadow-lg backdrop-blur-sm bg-rose-600/95 relative">${message}<button class="toast-close absolute top-1.5 right-2 bg-transparent border-none text-white/70 hover:text-white text-base cursor-pointer p-0.5 leading-none rounded" title="Dismiss">&times;</button></div></div>`;
 }

--- a/src/web/partials/toast.ts
+++ b/src/web/partials/toast.ts
@@ -1,0 +1,9 @@
+// Toast notification partial — injected via hx-swap-oob into #toast-container
+
+export function toastSuccess(message: string): string {
+  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast toast-success">${message}</div></div>`;
+}
+
+export function toastError(message: string): string {
+  return `<div id="toast-container" hx-swap-oob="afterbegin:#toast-container"><div class="toast toast-error">${message}<button class="toast-close" title="Dismiss">&times;</button></div></div>`;
+}

--- a/src/web/partials/translated-list.ts
+++ b/src/web/partials/translated-list.ts
@@ -1,0 +1,58 @@
+// Translated transactions list — grouped by Hebrew description with inline edit.
+
+import { escapeHtml } from "../layout.js";
+import { listTranslatedGrouped, type TranslatedGroup } from "../../db/repositories/translations.js";
+
+export function translatedList(): string {
+  const groups = listTranslatedGrouped();
+
+  if (groups.length === 0) {
+    return `<div id="translated-list">
+      <div class="empty-state">
+        <span class="empty-icon">&#128203;</span>
+        <p>No translated transactions yet</p>
+        <p class="text-muted">Translate merchants above or apply translation rules.</p>
+      </div>
+    </div>`;
+  }
+
+  const rows = groups.map((g) => translatedRow(g)).join("\n");
+
+  return `<div id="translated-list">${rows}</div>`;
+}
+
+function translatedRow(group: TranslatedGroup): string {
+  const hebrew = escapeHtml(group.description);
+  const english = escapeHtml(group.descriptionEn);
+  const totalFormatted = group.totalAmount.toLocaleString("he-IL", {
+    style: "currency",
+    currency: "ILS",
+    minimumFractionDigits: 0,
+  });
+  const countLabel = `${group.count} tx${group.count !== 1 ? "s" : ""}`;
+  const rowId = `translated-${simpleHash(group.description)}`;
+
+  return `<form class="translate-row" id="${rowId}"
+    hx-post="/api/translations/update"
+    hx-target="#translated-list"
+    hx-swap="outerHTML">
+    <div class="translate-source">
+      <span dir="rtl" lang="he">${hebrew}</span>
+      <div class="translate-source-meta">${countLabel}, ${totalFormatted}</div>
+    </div>
+    <div class="translate-arrow" aria-hidden="true">&#8594;</div>
+    <div class="translate-input-group">
+      <input type="hidden" name="hebrew" value="${hebrew}">
+      <input type="text" name="english" value="${english}" required style="margin:0;">
+    </div>
+    <button type="submit" hx-disabled-elt="this" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Save</button>
+  </form>`;
+}
+
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash).toString(36);
+}

--- a/src/web/partials/translated-list.ts
+++ b/src/web/partials/translated-list.ts
@@ -1,4 +1,5 @@
-// Translated transactions list — grouped by Hebrew description with inline edit.
+// Translated transactions list -- grouped by Hebrew description with inline edit.
+// Uses card-style rows matching the untranslated list design.
 
 import { escapeHtml } from "../layout.js";
 import { listTranslatedGrouped, type TranslatedGroup } from "../../db/repositories/translations.js";
@@ -8,10 +9,10 @@ export function translatedList(): string {
 
   if (groups.length === 0) {
     return `<div id="translated-list">
-      <div class="empty-state">
-        <span class="empty-icon">&#128203;</span>
-        <p>No translated transactions yet</p>
-        <p class="text-muted">Translate merchants above or apply translation rules.</p>
+      <div class="flex flex-col items-center justify-center text-center py-8">
+        <span class="text-3xl mb-2">&#128203;</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">No translated transactions yet</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm mt-1">Translate merchants above or apply translation rules.</p>
       </div>
     </div>`;
   }
@@ -28,24 +29,25 @@ function translatedRow(group: TranslatedGroup): string {
     style: "currency",
     currency: "ILS",
     minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
   });
   const countLabel = `${group.count} tx${group.count !== 1 ? "s" : ""}`;
   const rowId = `translated-${simpleHash(group.description)}`;
 
-  return `<form class="translate-row" id="${rowId}"
+  return `<form class="translate-row grid grid-cols-[minmax(140px,1fr)_auto_minmax(200px,1.2fr)_auto] gap-3 items-center p-3 mx-3 my-1.5 rounded-lg bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm hover:border-indigo-300 dark:hover:border-indigo-700 hover:shadow-md focus-within:ring-2 focus-within:ring-indigo-500/20 focus-within:border-indigo-500 transition-all" id="${rowId}"
     hx-post="/api/translations/update"
     hx-target="#translated-list"
     hx-swap="outerHTML">
-    <div class="translate-source">
-      <span dir="rtl" lang="he">${hebrew}</span>
-      <div class="translate-source-meta">${countLabel}, ${totalFormatted}</div>
+    <div class="min-w-0">
+      <span class="text-right text-sm font-medium block" dir="rtl" style="unicode-bidi:isolate;">${hebrew}</span>
+      <div class="text-zinc-500 dark:text-zinc-300 text-xs mt-0.5">${countLabel} &middot; ${totalFormatted}</div>
     </div>
-    <div class="translate-arrow" aria-hidden="true">&#8594;</div>
-    <div class="translate-input-group">
+    <div class="text-zinc-400 text-sm text-center opacity-50" aria-hidden="true">&#8594;</div>
+    <div class="min-w-0">
       <input type="hidden" name="hebrew" value="${hebrew}">
-      <input type="text" name="english" value="${english}" required style="margin:0;">
+      <input type="text" name="english" value="${english}" required class="m-0">
     </div>
-    <button type="submit" hx-disabled-elt="this" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Save</button>
+    <button type="submit" hx-disabled-elt="this" class="btn btn-outline btn-sm">Save</button>
   </form>`;
 }
 

--- a/src/web/partials/translation-rules-table.ts
+++ b/src/web/partials/translation-rules-table.ts
@@ -1,4 +1,4 @@
-// Translation rules table body partial — returned on add/delete for HTMX swap.
+// Translation rules table body partial -- returned on add/delete for HTMX swap.
 
 import { escapeHtml } from "../layout.js";
 
@@ -11,11 +11,11 @@ export interface TranslationRule {
 
 export function translationRulesTableBody(rules: TranslationRule[]): string {
   if (rules.length === 0) {
-    return `<tbody id="translation-rules-tbody"><tr><td colspan="4">
-      <div class="empty-state">
-        <span class="empty-icon">&#127760;</span>
-        <p>No translation rules defined yet</p>
-        <p class="text-muted">Translation rules convert Hebrew merchant names to English for easier reading.</p>
+    return `<tbody id="translation-rules-tbody"><tr><td colspan="4" class="px-4 py-8">
+      <div class="flex flex-col items-center justify-center text-center py-4">
+        <span class="text-3xl mb-2">&#127760;</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">No translation rules defined yet</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm mt-1">Translation rules convert Hebrew merchant names to English for easier reading.</p>
       </div>
     </td></tr></tbody>`;
   }
@@ -23,12 +23,19 @@ export function translationRulesTableBody(rules: TranslationRule[]): string {
   const rowsHtml = rules
     .map((r) => {
       const created = new Date(r.createdAt).toLocaleDateString("en-IL");
-      return `<tr>
-        <td data-label="English Name">${escapeHtml(r.englishName)}</td>
-        <td data-label="Match Pattern">${escapeHtml(r.matchPattern)}</td>
-        <td data-label="Created">${created}</td>
-        <td data-label="" class="actions">
-          <button hx-delete="/api/translations/rules/${r.id}" hx-target="#translation-rules-tbody" hx-swap="outerHTML" hx-confirm="Delete this rule?" class="outline secondary" title="Delete rule">&#10005;</button>
+      return `<tr class="border-b border-zinc-200 dark:border-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+        <td class="px-4 py-3 text-sm"><span class="font-medium text-zinc-900 dark:text-white">${escapeHtml(r.englishName)}</span></td>
+        <td class="px-4 py-3 text-sm" dir="rtl" style="unicode-bidi:isolate;">${escapeHtml(r.matchPattern)}</td>
+        <td class="px-4 py-3 text-sm text-zinc-500 dark:text-zinc-300">${created}</td>
+        <td class="px-4 py-3 text-sm text-right">
+          <button class="btn btn-ghost btn-ghost-danger"
+            hx-delete="/api/translations/rules/${r.id}"
+            hx-target="#translation-rules-tbody"
+            hx-swap="outerHTML"
+            hx-confirm="Delete this rule?"
+            title="Delete rule">
+            &#10005; Delete
+          </button>
         </td>
       </tr>`;
     })

--- a/src/web/partials/translation-rules-table.ts
+++ b/src/web/partials/translation-rules-table.ts
@@ -1,0 +1,38 @@
+// Translation rules table body partial — returned on add/delete for HTMX swap.
+
+import { escapeHtml } from "../layout.js";
+
+export interface TranslationRule {
+  id: number;
+  englishName: string;
+  matchPattern: string;
+  createdAt: string;
+}
+
+export function translationRulesTableBody(rules: TranslationRule[]): string {
+  if (rules.length === 0) {
+    return `<tbody id="translation-rules-tbody"><tr><td colspan="4">
+      <div class="empty-state">
+        <span class="empty-icon">&#127760;</span>
+        <p>No translation rules defined yet</p>
+        <p class="text-muted">Translation rules convert Hebrew merchant names to English for easier reading.</p>
+      </div>
+    </td></tr></tbody>`;
+  }
+
+  const rowsHtml = rules
+    .map((r) => {
+      const created = new Date(r.createdAt).toLocaleDateString("en-IL");
+      return `<tr>
+        <td data-label="English Name">${escapeHtml(r.englishName)}</td>
+        <td data-label="Match Pattern">${escapeHtml(r.matchPattern)}</td>
+        <td data-label="Created">${created}</td>
+        <td data-label="" class="actions">
+          <button hx-delete="/api/translations/rules/${r.id}" hx-target="#translation-rules-tbody" hx-swap="outerHTML" hx-confirm="Delete this rule?" class="outline secondary" title="Delete rule">&#10005;</button>
+        </td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<tbody id="translation-rules-tbody">${rowsHtml}</tbody>`;
+}

--- a/src/web/partials/untranslated-list.ts
+++ b/src/web/partials/untranslated-list.ts
@@ -1,0 +1,61 @@
+// Untranslated transactions list — grouped by Hebrew description with inline translate forms.
+
+import { escapeHtml } from "../layout.js";
+import { listUntranslatedGrouped, type UntranslatedGroup } from "../../db/repositories/translations.js";
+
+export function untranslatedList(): string {
+  const groups = listUntranslatedGrouped();
+
+  if (groups.length === 0) {
+    return `<div id="untranslated-list">
+      <div class="empty-state">
+        <span class="empty-icon">&#10003;</span>
+        <p>All translated!</p>
+        <p class="text-muted">Every transaction has an English name.</p>
+      </div>
+    </div>`;
+  }
+
+  const rows = groups.map((g) => untranslatedRow(g)).join("\n");
+
+  return `<div id="untranslated-list">${rows}</div>`;
+}
+
+function untranslatedRow(group: UntranslatedGroup): string {
+  const hebrew = escapeHtml(group.description);
+  // Use base64url-safe encoding for the Hebrew description in form data
+  const totalFormatted = group.totalAmount.toLocaleString("he-IL", {
+    style: "currency",
+    currency: "ILS",
+    minimumFractionDigits: 0,
+  });
+  const countLabel = `${group.count} tx${group.count !== 1 ? "s" : ""}`;
+  // Use the raw description as form value (URL-encoded by HTMX automatically)
+  const rowId = `translate-${simpleHash(group.description)}`;
+
+  return `<form class="translate-row" id="${rowId}"
+    hx-post="/api/translations/translate"
+    hx-target="#${rowId}"
+    hx-swap="outerHTML">
+    <div class="translate-source">
+      <span dir="rtl" lang="he">${hebrew}</span>
+      <div class="translate-source-meta">${countLabel}, ${totalFormatted}</div>
+    </div>
+    <div class="translate-arrow" aria-hidden="true">&#8594;</div>
+    <div class="translate-input-group">
+      <input type="hidden" name="hebrew" value="${hebrew}">
+      <input type="text" name="english" placeholder="English name..." required style="margin:0;">
+      <label><input type="checkbox" name="createRule" value="1"> rule</label>
+    </div>
+    <button type="submit" hx-disabled-elt="this" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Save</button>
+  </form>`;
+}
+
+// Simple hash for generating unique row IDs from Hebrew strings
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash).toString(36);
+}

--- a/src/web/partials/untranslated-list.ts
+++ b/src/web/partials/untranslated-list.ts
@@ -1,4 +1,5 @@
-// Untranslated transactions list — grouped by Hebrew description with inline translate forms.
+// Untranslated transactions list -- grouped by Hebrew description with inline translate forms.
+// Uses card-style rows with improved visual hierarchy for Hebrew->English mapping.
 
 import { escapeHtml } from "../layout.js";
 import { listUntranslatedGrouped, type UntranslatedGroup } from "../../db/repositories/translations.js";
@@ -8,10 +9,10 @@ export function untranslatedList(): string {
 
   if (groups.length === 0) {
     return `<div id="untranslated-list">
-      <div class="empty-state">
-        <span class="empty-icon">&#10003;</span>
-        <p>All translated!</p>
-        <p class="text-muted">Every transaction has an English name.</p>
+      <div class="flex flex-col items-center justify-center text-center py-8">
+        <span class="text-3xl mb-2">&#10003;</span>
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">All translated!</p>
+        <p class="text-zinc-500 dark:text-zinc-300 text-sm mt-1">Every transaction has an English name.</p>
       </div>
     </div>`;
   }
@@ -28,26 +29,27 @@ function untranslatedRow(group: UntranslatedGroup): string {
     style: "currency",
     currency: "ILS",
     minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
   });
   const countLabel = `${group.count} tx${group.count !== 1 ? "s" : ""}`;
   // Use the raw description as form value (URL-encoded by HTMX automatically)
   const rowId = `translate-${simpleHash(group.description)}`;
 
-  return `<form class="translate-row" id="${rowId}"
+  return `<form class="translate-row grid grid-cols-[minmax(140px,1fr)_auto_minmax(200px,1.2fr)_auto] gap-3 items-center p-3 mx-3 my-1.5 rounded-lg bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm hover:border-indigo-300 dark:hover:border-indigo-700 hover:shadow-md focus-within:ring-2 focus-within:ring-indigo-500/20 focus-within:border-indigo-500 transition-all" id="${rowId}"
     hx-post="/api/translations/translate"
     hx-target="#${rowId}"
     hx-swap="outerHTML">
-    <div class="translate-source">
-      <span dir="rtl" lang="he">${hebrew}</span>
-      <div class="translate-source-meta">${countLabel}, ${totalFormatted}</div>
+    <div class="min-w-0">
+      <span class="text-right text-sm font-medium block" dir="rtl" style="unicode-bidi:isolate;">${hebrew}</span>
+      <div class="text-zinc-500 dark:text-zinc-300 text-xs mt-0.5">${countLabel} &middot; ${totalFormatted}</div>
     </div>
-    <div class="translate-arrow" aria-hidden="true">&#8594;</div>
-    <div class="translate-input-group">
+    <div class="text-zinc-400 text-sm text-center opacity-50" aria-hidden="true">&#8594;</div>
+    <div class="flex items-center gap-2 min-w-0">
       <input type="hidden" name="hebrew" value="${hebrew}">
-      <input type="text" name="english" placeholder="English name..." required style="margin:0;">
-      <label><input type="checkbox" name="createRule" value="1"> rule</label>
+      <input type="text" name="english" placeholder="English name..." required class="m-0 flex-1">
+      <label class="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-300 whitespace-nowrap cursor-pointer" title="Also create a translation rule for future transactions"><input type="checkbox" name="createRule" value="1"> rule</label>
     </div>
-    <button type="submit" hx-disabled-elt="this" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;white-space:nowrap;">Save</button>
+    <button type="submit" hx-disabled-elt="this" class="btn btn-outline btn-sm">Save</button>
   </form>`;
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,0 +1,645 @@
+// Settings dashboard HTTP server — Bun.serve() with URL routing.
+// No framework, no build step. HTMX partials for inline updates.
+
+
+import { providersPage } from "./pages/providers.js";
+import { categoriesPage } from "./pages/categories.js";
+import { translationsPage } from "./pages/translations.js";
+import { providerLoginFields, providerAuthFields } from "./partials/provider-fields.js";
+import { providerCards, type ProviderCardData } from "./partials/provider-cards.js";
+import { categoryRulesTableBody } from "./partials/category-rules-table.js";
+import { categorySummaryTable } from "./partials/category-summary-table.js";
+import { categorySidebar } from "./partials/category-sidebar.js";
+import { categoryTxPanel } from "./partials/category-tx-panel.js";
+import { translationRulesTableBody } from "./partials/translation-rules-table.js";
+import { untranslatedList } from "./partials/untranslated-list.js";
+import { translatedList } from "./partials/translated-list.js";
+import { toastSuccess, toastError } from "./partials/toast.js";
+import { escapeHtml } from "./layout.js";
+import { listProviders, createProvider, deleteProvider, getProvider } from "../db/repositories/providers.js";
+import { hasCredentials, storeCredentials, deleteCredentials } from "../security/keychain.js";
+import { PROVIDERS, isValidCompanyId, type CompanyId } from "../types/provider.js";
+import { countTransactions, updateTransactionCategory } from "../db/repositories/transactions.js";
+import {
+  listCategoryRules,
+  addCategoryRule,
+  removeCategoryRule,
+  applyCategoryRules,
+  createCategory,
+  deleteCategory,
+  renameCategory,
+  categoryExists,
+  listAllCategories,
+} from "../db/repositories/categories.js";
+import {
+  listTranslationRules,
+  addTranslationRule,
+  removeTranslationRule,
+  applyTranslationRules,
+  translateByDescription,
+  updateTranslationByDescription,
+} from "../db/repositories/translations.js";
+import { syncProviders } from "../core/sync-engine.js";
+
+// Track active fetch so we don't allow concurrent syncs
+let activeFetch: { promise: Promise<void>; events: string[] } | null = null;
+
+export function startDashboard(port: number) {
+  const server = Bun.serve({
+    port,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
+      const method = req.method;
+
+      try {
+        // --- Pages ---
+        if (method === "GET" && (path === "/" || path === "")) {
+          return Response.redirect("/providers", 302);
+        }
+        if (method === "GET" && path === "/providers") {
+          return html(await providersPage());
+        }
+        if (method === "GET" && path === "/categories") {
+          const cat = url.searchParams.get("cat") ?? undefined;
+          return html(categoriesPage(cat));
+        }
+        if (method === "GET" && path === "/translations") {
+          return html(translationsPage());
+        }
+
+        // --- Provider API ---
+
+        // GET /api/providers/cards — provider cards partial (for HTMX refresh)
+        if (method === "GET" && path === "/api/providers/cards") {
+          return html(await providerCardsHtml());
+        }
+
+        // GET /api/providers/fields/:companyId — dynamic login fields
+        const fieldsMatch = path.match(/^\/api\/providers\/fields\/([a-zA-Z]+)$/);
+        if (method === "GET" && fieldsMatch) {
+          return html(providerLoginFields(fieldsMatch[1]));
+        }
+
+        // GET /api/providers/:id/auth-form — credential update form
+        const authFormMatch = path.match(/^\/api\/providers\/(\d+)\/auth-form$/);
+        if (method === "GET" && authFormMatch) {
+          const provider = getProvider(Number(authFormMatch[1]));
+          if (!provider) return html(toastError("Provider not found"), 404);
+          return html(providerAuthFields(provider.companyId, provider.id));
+        }
+
+        // POST /api/providers — add provider
+        if (method === "POST" && path === "/api/providers") {
+          const form = await parseForm(req);
+          const companyId = form.get("companyId") ?? "";
+          if (!isValidCompanyId(companyId)) {
+            return html(toastError("Invalid provider type."), 400);
+          }
+
+          const info = PROVIDERS[companyId];
+          const alias = form.get("alias") || companyId;
+
+          // Extract credentials from cred_* fields
+          const credentials: Record<string, string> = {};
+          for (const field of info.loginFields) {
+            const val = form.get(`cred_${field}`) ?? "";
+            if (field !== "otpLongTermToken" && !val) {
+              return html(toastError(`Missing required field: ${field}`), 400);
+            }
+            if (val) credentials[field] = val;
+          }
+
+          try {
+            await storeCredentials(alias, credentials);
+            // Zero credentials
+            for (const key of Object.keys(credentials)) credentials[key] = "";
+
+            createProvider(companyId, info.displayName, info.type, alias);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return html(await providerCardsHtml() + toastError(`Failed: ${msg}`));
+          }
+
+          return html(await providerCardsHtml() + toastSuccess("Provider added."));
+        }
+
+        // POST /api/providers/:id/auth — update credentials
+        const authMatch = path.match(/^\/api\/providers\/(\d+)\/auth$/);
+        if (method === "POST" && authMatch) {
+          const provider = getProvider(Number(authMatch[1]));
+          if (!provider) return html(toastError("Provider not found."), 404);
+
+          const info = PROVIDERS[provider.companyId as CompanyId];
+          if (!info) return html(toastError("Unknown provider type."), 400);
+
+          const form = await parseForm(req);
+          const credentials: Record<string, string> = {};
+          for (const field of info.loginFields) {
+            const val = form.get(`cred_${field}`) ?? "";
+            if (field !== "otpLongTermToken" && !val) {
+              return html(toastError(`Missing required field: ${field}`), 400);
+            }
+            if (val) credentials[field] = val;
+          }
+
+          try {
+            await storeCredentials(provider.alias, credentials);
+            for (const key of Object.keys(credentials)) credentials[key] = "";
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return html(toastError(`Failed: ${msg}`));
+          }
+
+          // Clear the auth form and show success toast
+          return html(toastSuccess("Credentials updated."));
+        }
+
+        // DELETE /api/providers/:id — remove provider
+        const deleteProviderMatch = path.match(/^\/api\/providers\/(\d+)$/);
+        if (method === "DELETE" && deleteProviderMatch) {
+          const provider = getProvider(Number(deleteProviderMatch[1]));
+          if (!provider) return html(toastError("Provider not found."), 404);
+
+          try {
+            await deleteCredentials(provider.alias).catch(() => {});
+            deleteProvider(provider.id);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return html(await providerCardsHtml() + toastError(`Failed: ${msg}`));
+          }
+
+          return html(await providerCardsHtml() + toastSuccess(`Removed ${provider.displayName}.`));
+        }
+
+        // --- Category Entity API ---
+
+        // POST /api/categories — create empty category
+        if (method === "POST" && path === "/api/categories") {
+          const form = await parseForm(req);
+          const name = form.get("name")?.trim() ?? "";
+          if (!name) return html(toastError("Category name is required."), 400);
+
+          const created = createCategory(name);
+          if (!created) {
+            return html(categorySummaryTable() + toastError("Category already exists."));
+          }
+          return html(categorySummaryTable() + toastSuccess(`Category "${name}" created.`));
+        }
+
+        // GET /api/categories/summary-table — category summary tbody (for cancel/refresh)
+        if (method === "GET" && path === "/api/categories/summary-table") {
+          return html(categorySummaryTable());
+        }
+
+        // GET /api/categories/sidebar — sidebar partial
+        if (method === "GET" && path === "/api/categories/sidebar") {
+          const active = url.searchParams.get("active") ?? undefined;
+          return html(categorySidebar(active));
+        }
+
+        // GET /api/categories/transactions — tx panel for category
+        if (method === "GET" && path === "/api/categories/transactions") {
+          const cat = url.searchParams.get("cat") ?? "Uncategorized";
+          return html(categoryTxPanel(cat));
+        }
+
+        // GET /api/categories/:name/edit — inline rename form
+        const catEditMatch = path.match(/^\/api\/categories\/([^/]+)\/edit$/);
+        if (method === "GET" && catEditMatch) {
+          const name = decodeURIComponent(catEditMatch[1]);
+          return html(inlineRenameForm(name));
+        }
+
+        // POST /api/categories/:name/rename — execute rename
+        const catRenameMatch = path.match(/^\/api\/categories\/([^/]+)\/rename$/);
+        if (method === "POST" && catRenameMatch) {
+          const oldName = decodeURIComponent(catRenameMatch[1]);
+          const form = await parseForm(req);
+          const newName = form.get("newName")?.trim() ?? "";
+          if (!newName) return html(toastError("New name is required."), 400);
+          if (newName === oldName) return html(categorySummaryTable() + toastSuccess("No change."));
+
+          // If destination exists, this is a merge
+          const exists = categoryExists(newName);
+          const result = renameCategory(oldName, newName);
+          const verb = exists ? "merged into" : "renamed to";
+          return html(categorySummaryTable() + toastSuccess(`"${oldName}" ${verb} "${newName}" (${result.transactionsUpdated} txs, ${result.rulesUpdated} rules).`));
+        }
+
+        // GET /api/categories/:name/delete-confirm — delete confirmation panel
+        const catDeleteConfirmMatch = path.match(/^\/api\/categories\/([^/]+)\/delete-confirm$/);
+        if (method === "GET" && catDeleteConfirmMatch) {
+          const name = decodeURIComponent(catDeleteConfirmMatch[1]);
+          return html(deleteConfirmPanel(name));
+        }
+
+        // POST /api/categories/:name/delete — execute delete
+        const catDeleteMatch = path.match(/^\/api\/categories\/([^/]+)\/delete$/);
+        if (method === "POST" && catDeleteMatch) {
+          const name = decodeURIComponent(catDeleteMatch[1]);
+          const form = await parseForm(req);
+          const moveTo = form.get("moveTo")?.trim() ?? "Uncategorized";
+
+          if (name === "Uncategorized") {
+            return html(toastError("Cannot delete Uncategorized."), 400);
+          }
+
+          const result = deleteCategory(name, moveTo);
+          // Return updated summary table + cleared action panel + toast
+          return html(
+            categorySummaryTable() +
+            `<div id="category-action-panel" hx-swap-oob="innerHTML:#category-action-panel"></div>` +
+            toastSuccess(`Deleted "${name}". Moved ${result.transactionsUpdated} txs to "${moveTo}".`)
+          );
+        }
+
+        // --- Category Rules API ---
+
+        // POST /api/categories/rules — add rule
+        if (method === "POST" && path === "/api/categories/rules") {
+          const form = await parseForm(req);
+          const category = form.get("category")?.trim() ?? "";
+          const priority = Number(form.get("priority") ?? "10");
+          const descriptionPattern = form.get("descriptionPattern")?.trim() ?? "";
+          const descriptionMode = form.get("descriptionMode") ?? "substring";
+          const memoPattern = form.get("memoPattern")?.trim() ?? "";
+          const direction = form.get("direction")?.trim() ?? "";
+
+          if (!category) return html(toastError("Category name is required."), 400);
+          if (!descriptionPattern && !memoPattern) {
+            return html(toastError("At least one condition (description or memo) is required."), 400);
+          }
+
+          const conditions: Record<string, unknown> = {};
+          if (descriptionPattern) {
+            conditions.description = { pattern: descriptionPattern, mode: descriptionMode };
+          }
+          if (memoPattern) {
+            conditions.memo = { pattern: memoPattern, mode: "substring" };
+          }
+          if (direction) {
+            conditions.direction = direction;
+          }
+
+          try {
+            addCategoryRule(category, conditions as any, priority);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return html(categoryRulesTableBody(listCategoryRules()) + toastError(`Failed: ${msg}`));
+          }
+
+          return html(categoryRulesTableBody(listCategoryRules()) + toastSuccess("Rule added."));
+        }
+
+        // DELETE /api/categories/rules/:id
+        const deleteCatRuleMatch = path.match(/^\/api\/categories\/rules\/(\d+)$/);
+        if (method === "DELETE" && deleteCatRuleMatch) {
+          const id = Number(deleteCatRuleMatch[1]);
+          const removed = removeCategoryRule(id);
+          if (!removed) return html(categoryRulesTableBody(listCategoryRules()) + toastError("Rule not found."));
+          return html(categoryRulesTableBody(listCategoryRules()) + toastSuccess("Rule deleted."));
+        }
+
+        // POST /api/categories/apply
+        if (method === "POST" && path === "/api/categories/apply") {
+          const form = await parseForm(req);
+          const scope = (form.get("scope") ?? "uncategorized") as "uncategorized" | "all";
+          const result = applyCategoryRules({ scope });
+          return html(categorySummaryTable() + toastSuccess(`Applied rules: ${result.applied} transaction${result.applied !== 1 ? "s" : ""} categorized.`));
+        }
+
+        // --- Transaction API ---
+
+        // PATCH /api/transactions/:id/category — move single tx to different category
+        const txCategoryMatch = path.match(/^\/api\/transactions\/(\d+)\/category$/);
+        if (method === "PATCH" && txCategoryMatch) {
+          const txId = Number(txCategoryMatch[1]);
+          const form = await parseForm(req);
+          const newCategory = form.get("category")?.trim() ?? "";
+          const fromCategory = form.get("from")?.trim() ?? "";
+
+          if (!newCategory) return html(toastError("Category is required."), 400);
+
+          const updated = updateTransactionCategory(txId, newCategory);
+          if (!updated) return html(toastError("Transaction not found."), 404);
+
+          // Return moved-state row that fades out, plus OOB sidebar update + toast
+          const movedRow = `<div class="tx-row tx-row--moved" id="tx-row-${txId}">
+            <div style="grid-column:1/-1;text-align:center;padding:0.5rem;color:var(--pico-primary);">
+              Moved to ${escapeHtml(newCategory)}
+            </div>
+          </div>`;
+
+          const oobSidebar = `<div id="category-sidebar" hx-swap-oob="outerHTML:#category-sidebar">${categorySidebar(fromCategory || undefined)}</div>`;
+          const toast = toastSuccess(`Moved to "${newCategory}".`);
+
+          return html(movedRow + oobSidebar + toast);
+        }
+
+        // --- Translation Rules API ---
+
+        // POST /api/translations/rules
+        if (method === "POST" && path === "/api/translations/rules") {
+          const form = await parseForm(req);
+          const englishName = form.get("englishName")?.trim() ?? "";
+          const matchPattern = form.get("matchPattern")?.trim() ?? "";
+
+          if (!englishName || !matchPattern) {
+            return html(toastError("Both English name and match pattern are required."), 400);
+          }
+
+          try {
+            addTranslationRule(englishName, matchPattern);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return html(translationRulesTableBody(listTranslationRules()) + toastError(`Failed: ${msg}`));
+          }
+
+          return html(translationRulesTableBody(listTranslationRules()) + toastSuccess("Rule added."));
+        }
+
+        // DELETE /api/translations/rules/:id
+        const deleteTransRuleMatch = path.match(/^\/api\/translations\/rules\/(\d+)$/);
+        if (method === "DELETE" && deleteTransRuleMatch) {
+          const id = Number(deleteTransRuleMatch[1]);
+          const removed = removeTranslationRule(id);
+          if (!removed) return html(translationRulesTableBody(listTranslationRules()) + toastError("Rule not found."));
+          return html(translationRulesTableBody(listTranslationRules()) + toastSuccess("Rule deleted."));
+        }
+
+        // POST /api/translations/apply
+        if (method === "POST" && path === "/api/translations/apply") {
+          const result = applyTranslationRules();
+          return html(toastSuccess(`Applied translations: ${result.applied} transaction${result.applied !== 1 ? "s" : ""} updated.`));
+        }
+
+        // GET /api/translations/untranslated — untranslated list partial
+        if (method === "GET" && path === "/api/translations/untranslated") {
+          return html(untranslatedList());
+        }
+
+        // POST /api/translations/translate — translate a Hebrew description + optionally create rule
+        if (method === "POST" && path === "/api/translations/translate") {
+          const form = await parseForm(req);
+          const hebrew = form.get("hebrew")?.trim() ?? "";
+          const english = form.get("english")?.trim() ?? "";
+          const shouldCreateRule = form.get("createRule") === "1";
+
+          if (!hebrew || !english) {
+            return html(toastError("Hebrew description and English name are required."), 400);
+          }
+
+          const count = translateByDescription(hebrew, english);
+
+          if (shouldCreateRule) {
+            try {
+              addTranslationRule(english, hebrew);
+            } catch {
+              // Rule might already exist — that's fine
+            }
+          }
+
+          // Return a success row that fades out
+          return html(`<div class="translate-row translate-row-success" style="justify-content:center;padding:0.75rem;">
+            Translated ${count} transaction${count !== 1 ? "s" : ""} as "${escapeHtml(english)}"
+          </div>`);
+        }
+
+        // POST /api/translations/update — edit an existing translation
+        if (method === "POST" && path === "/api/translations/update") {
+          const form = await parseForm(req);
+          const hebrew = form.get("hebrew")?.trim() ?? "";
+          const english = form.get("english")?.trim() ?? "";
+
+          if (!hebrew || !english) {
+            return html(toastError("Hebrew description and English name are required."), 400);
+          }
+
+          const count = updateTranslationByDescription(hebrew, english);
+
+          // Return refreshed translated list + toast
+          return html(translatedList() + toastSuccess(`Updated ${count} transaction${count !== 1 ? "s" : ""} to "${english}".`));
+        }
+
+        // GET /api/translations/translated — translated list partial
+        if (method === "GET" && path === "/api/translations/translated") {
+          return html(translatedList());
+        }
+
+        // --- Fetch / Sync API ---
+
+        // POST /api/fetch — start a fetch (headless). Returns SSE stream.
+        // POST /api/fetch?visible=1 — retry with visible browser (for OTP/2FA)
+        if (method === "POST" && path === "/api/fetch") {
+          if (activeFetch) {
+            return html(toastError("A fetch is already in progress."), 409);
+          }
+
+          const form = await parseForm(req);
+          const visible = form.get("visible") === "1";
+
+          return startFetchSSE(visible);
+        }
+
+        // GET /api/fetch/events — SSE stream for fetch progress
+        if (method === "GET" && path === "/api/fetch/events") {
+          return fetchEventsSSE();
+        }
+
+        // --- 404 ---
+        return new Response("Not found", { status: 404 });
+      } catch (err) {
+        console.error("Dashboard error:", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        return html(toastError(`Server error: ${msg}`), 500);
+      }
+    },
+  });
+
+  return server;
+}
+
+// --- Helpers ---
+
+function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+async function parseForm(req: Request): Promise<Map<string, string>> {
+  const contentType = req.headers.get("content-type") ?? "";
+  const result = new Map<string, string>();
+
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const text = await req.text();
+    const params = new URLSearchParams(text);
+    for (const [key, value] of params) {
+      result.set(key, value);
+    }
+  } else if (contentType.includes("multipart/form-data")) {
+    const formData = await req.formData();
+    for (const [key, value] of formData) {
+      if (typeof value === "string") result.set(key, value);
+    }
+  }
+
+  return result;
+}
+
+// Inline rename form — replaces category name cell
+function inlineRenameForm(name: string): string {
+  const encoded = encodeURIComponent(name);
+  return `<form hx-post="/api/categories/${encoded}/rename"
+    hx-target="#category-summary-tbody" hx-swap="outerHTML"
+    style="display:flex;gap:0.3rem;align-items:center;margin:0;">
+    <input type="text" name="newName" value="${escapeHtml(name)}" required
+      style="margin:0;padding:0.2rem 0.4rem;font-size:0.85rem;height:auto;">
+    <button type="submit" class="outline" style="margin:0;padding:0.2rem 0.5rem;font-size:0.8rem;white-space:nowrap;">OK</button>
+    <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.5rem;font-size:0.8rem;white-space:nowrap;"
+      hx-get="/api/categories/summary-table" hx-target="#category-summary-tbody" hx-swap="outerHTML">Cancel</button>
+  </form>`;
+}
+
+// Delete confirmation panel — appears in #category-action-panel
+function deleteConfirmPanel(name: string): string {
+  const encoded = encodeURIComponent(name);
+  const allCats = listAllCategories().filter((c) => c !== name);
+  const options = allCats
+    .map((c) => `<option value="${escapeHtml(c)}"${c === "Uncategorized" ? " selected" : ""}>${escapeHtml(c)}</option>`)
+    .join("");
+
+  const txCount = countTransactions({ category: name === "Uncategorized" ? null : name });
+
+  return `<div class="category-action-panel">
+    <form hx-post="/api/categories/${encoded}/delete"
+      hx-target="#category-summary-tbody" hx-swap="outerHTML"
+      style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;margin:0;">
+      <strong>Delete "${escapeHtml(name)}"</strong>
+      <span class="text-muted">(${txCount} transaction${txCount !== 1 ? "s" : ""})</span>
+      <span>Move to:</span>
+      <select name="moveTo" style="margin:0;font-size:0.85rem;padding:0.3rem;height:auto;width:auto;">
+        ${options}
+      </select>
+      <button type="submit" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;">Confirm Delete</button>
+      <button type="button" class="outline secondary" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;"
+        onclick="document.getElementById('category-action-panel').innerHTML=''">Cancel</button>
+    </form>
+  </div>`;
+}
+
+async function providerCardsHtml(): Promise<string> {
+  const providers = listProviders();
+  const authStatuses = await Promise.all(
+    providers.map((p) => hasCredentials(p.alias)),
+  );
+  const cards: ProviderCardData[] = providers.map((p, i) => ({
+    provider: p,
+    hasAuth: authStatuses[i],
+    txCount: countTransactions({ providerId: p.id }),
+  }));
+  return providerCards(cards);
+}
+
+function startFetchSSE(visible: boolean): Response {
+  const events: string[] = [];
+  const listeners: Set<(event: string) => void> = new Set();
+
+  function pushEvent(data: string) {
+    events.push(data);
+    for (const listener of listeners) listener(data);
+  }
+
+  // Start fetch in background
+  const providers = listProviders();
+  if (providers.length === 0) {
+    return html(toastError("No providers configured."), 400);
+  }
+
+  pushEvent(JSON.stringify({ type: "start", providers: providers.map((p) => p.alias), visible }));
+
+  const fetchPromise = syncProviders(providers, {
+    visible,
+    onProgress: (alias, stage) => {
+      pushEvent(JSON.stringify({ type: "progress", alias, stage }));
+    },
+  })
+    .then((result) => {
+      const summary = result.results.map((r) => ({
+        alias: r.alias,
+        success: r.success,
+        added: r.transactionsAdded,
+        updated: r.transactionsUpdated,
+        error: r.error,
+      }));
+      pushEvent(JSON.stringify({
+        type: "done",
+        success: !result.hasErrors,
+        totalAdded: result.totalAdded,
+        totalUpdated: result.totalUpdated,
+        results: summary,
+      }));
+    })
+    .catch((err) => {
+      pushEvent(JSON.stringify({ type: "error", message: err instanceof Error ? err.message : String(err) }));
+    })
+    .finally(() => {
+      activeFetch = null;
+    });
+
+  activeFetch = { promise: fetchPromise, events };
+
+  // Return an SSE response that streams events
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+
+      // Send any events that already happened
+      for (const evt of events) {
+        controller.enqueue(encoder.encode(`data: ${evt}\n\n`));
+      }
+
+      // Listen for new events
+      const listener = (data: string) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          const parsed = JSON.parse(data);
+          if (parsed.type === "done" || parsed.type === "error") {
+            listeners.delete(listener);
+            controller.close();
+          }
+        } catch {
+          // ignore encoding errors on closed stream
+        }
+      };
+      listeners.add(listener);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function fetchEventsSSE(): Response {
+  if (!activeFetch) {
+    // No active fetch — send an immediate "idle" event
+    const body = `data: ${JSON.stringify({ type: "idle" })}\n\n`;
+    return new Response(body, {
+      headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+    });
+  }
+
+  // Replay stored events from the active fetch
+  const events = activeFetch.events;
+  const body = events.map((e) => `data: ${e}\n\n`).join("");
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+  });
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,7 +1,7 @@
 // Settings dashboard HTTP server — Bun.serve() with URL routing.
-// No framework, no build step. HTMX partials for inline updates.
+// HTMX partials for inline updates. Tailwind CSS built via @tailwindcss/cli.
 
-
+import { resolve } from "node:path";
 import { providersPage } from "./pages/providers.js";
 import { categoriesPage } from "./pages/categories.js";
 import { translationsPage } from "./pages/translations.js";
@@ -44,6 +44,9 @@ import { syncProviders } from "../core/sync-engine.js";
 // Track active fetch so we don't allow concurrent syncs
 let activeFetch: { promise: Promise<void>; events: string[] } | null = null;
 
+// Resolve path to built CSS (import.meta.dir is Bun-native, handles Windows)
+const cssPath = resolve(import.meta.dir, "dist/styles.css");
+
 export function startDashboard(port: number) {
   const server = Bun.serve({
     port,
@@ -53,6 +56,17 @@ export function startDashboard(port: number) {
       const method = req.method;
 
       try {
+        // --- Static assets ---
+        if (method === "GET" && path === "/styles.css") {
+          const file = Bun.file(cssPath);
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: { "Content-Type": "text/css; charset=utf-8", "Cache-Control": "public, max-age=3600" },
+            });
+          }
+          return new Response("/* CSS not built */", { status: 404, headers: { "Content-Type": "text/css" } });
+        }
+
         // --- Pages ---
         if (method === "GET" && (path === "/" || path === "")) {
           return Response.redirect("/providers", 302);
@@ -326,7 +340,7 @@ export function startDashboard(port: number) {
 
           // Return moved-state row that fades out, plus OOB sidebar update + toast
           const movedRow = `<div class="tx-row tx-row--moved" id="tx-row-${txId}">
-            <div style="grid-column:1/-1;text-align:center;padding:0.5rem;color:var(--pico-primary);">
+            <div class="col-span-full text-center py-2 text-indigo-600 dark:text-indigo-400 text-sm font-medium">
               Moved to ${escapeHtml(newCategory)}
             </div>
           </div>`;
@@ -401,7 +415,7 @@ export function startDashboard(port: number) {
           }
 
           // Return a success row that fades out
-          return html(`<div class="translate-row translate-row-success" style="justify-content:center;padding:0.75rem;">
+          return html(`<div class="translate-row translate-row-success flex items-center justify-center p-3 mx-3 my-1.5 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 text-sm font-medium">
             Translated ${count} transaction${count !== 1 ? "s" : ""} as "${escapeHtml(english)}"
           </div>`);
         }
@@ -489,21 +503,20 @@ async function parseForm(req: Request): Promise<Map<string, string>> {
   return result;
 }
 
-// Inline rename form — replaces category name cell
+// Inline rename form -- replaces category name cell
 function inlineRenameForm(name: string): string {
   const encoded = encodeURIComponent(name);
-  return `<form hx-post="/api/categories/${encoded}/rename"
-    hx-target="#category-summary-tbody" hx-swap="outerHTML"
-    style="display:flex;gap:0.3rem;align-items:center;margin:0;">
+  return `<form class="flex items-center gap-1.5" hx-post="/api/categories/${encoded}/rename"
+    hx-target="#category-summary-tbody" hx-swap="outerHTML">
     <input type="text" name="newName" value="${escapeHtml(name)}" required
-      style="margin:0;padding:0.2rem 0.4rem;font-size:0.85rem;height:auto;">
-    <button type="submit" class="outline" style="margin:0;padding:0.2rem 0.5rem;font-size:0.8rem;white-space:nowrap;">OK</button>
-    <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.5rem;font-size:0.8rem;white-space:nowrap;"
+      class="min-w-[8rem]">
+    <button type="submit" class="btn btn-outline btn-sm">OK</button>
+    <button type="button" class="btn btn-outline btn-sm"
       hx-get="/api/categories/summary-table" hx-target="#category-summary-tbody" hx-swap="outerHTML">Cancel</button>
   </form>`;
 }
 
-// Delete confirmation panel — appears in #category-action-panel
+// Delete confirmation panel -- appears in #category-action-panel
 function deleteConfirmPanel(name: string): string {
   const encoded = encodeURIComponent(name);
   const allCats = listAllCategories().filter((c) => c !== name);
@@ -513,18 +526,17 @@ function deleteConfirmPanel(name: string): string {
 
   const txCount = countTransactions({ category: name === "Uncategorized" ? null : name });
 
-  return `<div class="category-action-panel">
-    <form hx-post="/api/categories/${encoded}/delete"
-      hx-target="#category-summary-tbody" hx-swap="outerHTML"
-      style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;margin:0;">
-      <strong>Delete "${escapeHtml(name)}"</strong>
-      <span class="text-muted">(${txCount} transaction${txCount !== 1 ? "s" : ""})</span>
-      <span>Move to:</span>
-      <select name="moveTo" style="margin:0;font-size:0.85rem;padding:0.3rem;height:auto;width:auto;">
+  return `<div class="p-3 bg-indigo-50 dark:bg-indigo-900/20 border-b border-zinc-200 dark:border-zinc-800 flex items-center gap-2 flex-wrap text-sm">
+    <form class="flex items-center gap-2 flex-wrap" hx-post="/api/categories/${encoded}/delete"
+      hx-target="#category-summary-tbody" hx-swap="outerHTML">
+      <strong class="text-sm">Delete &ldquo;${escapeHtml(name)}&rdquo;</strong>
+      <span class="text-zinc-500 dark:text-zinc-300 text-sm">(${txCount} tx${txCount !== 1 ? "s" : ""})</span>
+      <span class="text-sm">Move to:</span>
+      <select name="moveTo" class="m-0 text-sm py-1 px-2 h-auto w-auto">
         ${options}
       </select>
-      <button type="submit" class="outline" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;">Confirm Delete</button>
-      <button type="button" class="outline secondary" style="margin:0;padding:0.3rem 0.75rem;font-size:0.85rem;"
+      <button type="submit" class="btn btn-outline btn-sm">Confirm</button>
+      <button type="button" class="btn btn-outline btn-sm"
         onclick="document.getElementById('category-action-panel').innerHTML=''">Cancel</button>
     </form>
   </div>`;

--- a/src/web/styles.css
+++ b/src/web/styles.css
@@ -1,0 +1,539 @@
+@import "tailwindcss";
+
+/* Scan .ts template files for Tailwind class names */
+@source "./**/*.ts";
+
+/* Class-based dark mode (Tailwind v4 defaults to media query) */
+@variant dark (&:where(.dark, .dark *));
+
+/* ══════════════════════════════════════════════
+   KolShek Design System
+   ──────────────────────────────────────────────
+   Palette:  Indigo primary · Zinc neutrals
+   Style:    Clean, minimal chrome, generous whitespace
+   Dark:     True-black zinc-950 base
+   ══════════════════════════════════════════════ */
+
+@theme {
+  --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── Layout Shell ── */
+
+/* Body: subtle warm gradient in light, deep dark with faint radial glow */
+.ks-body {
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #18181b;
+  background:
+    linear-gradient(175deg, #fafafa 0%, #f0f0f4 40%, #eef2ff 100%);
+}
+.dark .ks-body {
+  color: #e4e4e7;
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(99, 102, 241, 0.06) 0%, transparent 60%),
+    #09090b;
+}
+
+/* Header: frosted glass with subtle gradient and top-edge highlight */
+.ks-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  backdrop-filter: blur(16px) saturate(1.6);
+  -webkit-backdrop-filter: blur(16px) saturate(1.6);
+  border-bottom: 1px solid #e4e4e7;
+  background:
+    linear-gradient(to right, rgba(255,255,255,0.92), rgba(238,242,255,0.88));
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+.dark .ks-header {
+  border-color: #27272a;
+  background:
+    linear-gradient(to right, rgba(24, 24, 27, 0.88), rgba(30, 27, 50, 0.85));
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* Brand mark: shekel sign in a gradient accent square */
+.ks-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  user-select: none;
+}
+.ks-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  color: #fff;
+  box-shadow:
+    0 1px 3px rgba(79, 70, 229, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  transition: transform 0.2s var(--ease-spring), box-shadow 0.2s var(--ease-smooth);
+}
+.ks-brand:hover .ks-brand-mark {
+  transform: scale(1.08) rotate(-3deg);
+  box-shadow:
+    0 2px 8px rgba(79, 70, 229, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+.dark .ks-brand-mark {
+  background: linear-gradient(135deg, #818cf8 0%, #6366f1 100%);
+  box-shadow:
+    0 1px 6px rgba(129, 140, 248, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+.ks-brand-text {
+  font-weight: 700;
+  font-size: 0.9375rem;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #18181b 30%, #4f46e5 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.dark .ks-brand-text {
+  background: linear-gradient(135deg, #f4f4f5 30%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Nav pills: rounded capsule active states */
+.nav-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.5rem;
+  color: #71717a;
+  text-decoration: none;
+  transition: color 0.15s var(--ease-smooth), background 0.15s var(--ease-smooth);
+}
+.nav-pill:hover {
+  color: #18181b;
+  background: rgba(0, 0, 0, 0.04);
+}
+.dark .nav-pill {
+  color: #a1a1aa;
+}
+.dark .nav-pill:hover {
+  color: #f4f4f5;
+  background: rgba(255, 255, 255, 0.06);
+}
+.nav-pill--active {
+  color: #4f46e5;
+  background: rgba(79, 70, 229, 0.08);
+}
+.nav-pill--active:hover {
+  color: #4f46e5;
+  background: rgba(79, 70, 229, 0.12);
+}
+.dark .nav-pill--active {
+  color: #a5b4fc;
+  background: rgba(129, 140, 248, 0.12);
+}
+.dark .nav-pill--active:hover {
+  color: #a5b4fc;
+  background: rgba(129, 140, 248, 0.16);
+}
+
+/* Nav badges: gradient pill with soft glow */
+.nav-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.125rem;
+  height: 1.125rem;
+  padding: 0 0.3rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  color: #fff;
+  box-shadow: 0 0 6px rgba(99, 102, 241, 0.35);
+  letter-spacing: 0.02em;
+}
+.dark .nav-badge {
+  background: linear-gradient(135deg, #818cf8, #6366f1);
+  box-shadow: 0 0 8px rgba(129, 140, 248, 0.3);
+}
+
+/* Theme toggle: tactile rounded button with SVG icons */
+.ks-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  margin-left: 0.375rem;
+  padding: 0;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: #71717a;
+  cursor: pointer;
+  transition: all 0.2s var(--ease-smooth);
+}
+.ks-theme-toggle:hover {
+  background: rgba(79, 70, 229, 0.06);
+  border-color: #a5b4fc;
+  color: #4f46e5;
+  transform: rotate(15deg);
+}
+.ks-theme-toggle:active {
+  transform: scale(0.92) rotate(15deg);
+}
+.dark .ks-theme-toggle {
+  border-color: #3f3f46;
+  color: #a1a1aa;
+}
+.dark .ks-theme-toggle:hover {
+  background: rgba(129, 140, 248, 0.1);
+  border-color: #6366f1;
+  color: #a5b4fc;
+}
+.ks-theme-toggle svg {
+  transition: transform 0.3s var(--ease-spring), opacity 0.2s var(--ease-smooth);
+}
+.ks-theme-toggle:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+/* ── Form base styles ── */
+input[type="text"], input[type="search"], input[type="number"],
+input[type="password"], input[type="email"], select, textarea {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-family: inherit;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.5rem;
+  background: #fff;
+  color: #18181b;
+  transition: border-color 0.2s var(--ease-smooth), box-shadow 0.2s var(--ease-smooth), background-color 0.2s var(--ease-smooth);
+}
+.dark input[type="text"], .dark input[type="search"], .dark input[type="number"],
+.dark input[type="password"], .dark input[type="email"], .dark select, .dark textarea {
+  background: #18181b;
+  border-color: #3f3f46;
+  color: #fafafa;
+}
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12), 0 1px 2px rgba(99, 102, 241, 0.08);
+  background: #fefeff;
+}
+.dark input:focus, .dark select:focus, .dark textarea:focus {
+  border-color: #818cf8;
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.15), 0 0 12px rgba(129, 140, 248, 0.06);
+  background: #1a1a1f;
+}
+input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #4f46e5;
+}
+label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #3f3f46;
+  margin-bottom: 0.25rem;
+  letter-spacing: 0.01em;
+}
+.dark label { color: #d4d4d8; }
+label input, label select { margin-top: 0.25rem; }
+
+/* ── Buttons ── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  padding: 0.45rem 0.875rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s var(--ease-smooth);
+  white-space: nowrap;
+  border: none;
+  letter-spacing: 0.01em;
+  position: relative;
+}
+.btn-sm { font-size: 0.75rem; padding: 0.3rem 0.6rem; border-radius: 0.375rem; }
+
+.btn-primary {
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 50%, #4338ca 100%);
+  color: #fff;
+  box-shadow:
+    0 1px 2px rgba(79, 70, 229, 0.25),
+    0 0 0 1px rgba(79, 70, 229, 0.12) inset;
+}
+.btn-primary:hover {
+  background: linear-gradient(135deg, #6366f1 0%, #4338ca 50%, #3730a3 100%);
+  box-shadow:
+    0 3px 8px rgba(79, 70, 229, 0.3),
+    0 1px 2px rgba(79, 70, 229, 0.2),
+    0 0 0 1px rgba(79, 70, 229, 0.15) inset;
+  transform: translateY(-0.5px);
+}
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px #fff,
+    0 0 0 4px #6366f1,
+    0 1px 2px rgba(79, 70, 229, 0.25);
+}
+.dark .btn-primary:focus-visible {
+  box-shadow:
+    0 0 0 2px #18181b,
+    0 0 0 4px #818cf8,
+    0 1px 2px rgba(129, 140, 248, 0.3);
+}
+.btn-primary:active { transform: scale(0.98) translateY(0); }
+.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; background: #4f46e5; transform: none; }
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid #e4e4e7;
+  color: #3f3f46;
+}
+.dark .btn-outline { border-color: #3f3f46; color: #d4d4d8; }
+.btn-outline:hover { background: #f4f4f5; border-color: #d4d4d8; }
+.dark .btn-outline:hover { background: #27272a; border-color: #52525b; }
+
+.btn-ghost {
+  background: transparent;
+  color: #71717a;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 0.375rem;
+}
+.dark .btn-ghost { color: #a1a1aa; }
+.btn-ghost:hover {
+  background: rgba(99, 102, 241, 0.08);
+  color: #4f46e5;
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.06);
+}
+.dark .btn-ghost:hover {
+  background: rgba(129, 140, 248, 0.1);
+  color: #a5b4fc;
+  box-shadow: 0 0 0 1px rgba(129, 140, 248, 0.08);
+}
+.btn-ghost-danger:hover {
+  background: rgba(244, 63, 94, 0.06);
+  color: #e11d48;
+}
+.dark .btn-ghost-danger:hover {
+  background: rgba(244, 63, 94, 0.1);
+  color: #fb7185;
+}
+
+/* ── Card ── */
+.card {
+  background: #fff;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.75rem;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.04),
+    0 4px 12px rgba(79, 70, 229, 0.03);
+  overflow: hidden;
+  transition: box-shadow 0.2s var(--ease-smooth), border-color 0.2s var(--ease-smooth);
+}
+.dark .card {
+  background: #18181b;
+  border-color: #27272a;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid #f4f4f5;
+  background: linear-gradient(180deg, #fafafa 0%, #f6f6f7 100%);
+  border-left: 3px solid transparent;
+}
+.dark .card-header {
+  border-color: #27272a;
+  background: linear-gradient(180deg, #161618 0%, #131315 100%);
+  border-left-color: transparent;
+}
+
+/* Card accent variant: left border in primary color */
+.card-accent {
+  border-left: 3px solid #6366f1;
+}
+.dark .card-accent {
+  border-left-color: #818cf8;
+}
+.card-accent .card-header {
+  border-left: none;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.04) 0%, #fafafa 100%);
+}
+.dark .card-accent .card-header {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.06) 0%, #141414 100%);
+}
+
+/* ── Badges ── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 9999px;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+  border: 1px solid transparent;
+  transition: background-color 0.2s var(--ease-smooth);
+}
+.badge-indigo {
+  background: rgba(99, 102, 241, 0.1);
+  color: #4f46e5;
+  border-color: rgba(99, 102, 241, 0.15);
+}
+.dark .badge-indigo {
+  background: rgba(129, 140, 248, 0.12);
+  color: #a5b4fc;
+  border-color: rgba(129, 140, 248, 0.18);
+}
+.badge-emerald {
+  background: rgba(16, 185, 129, 0.1);
+  color: #059669;
+  border-color: rgba(16, 185, 129, 0.15);
+}
+.dark .badge-emerald {
+  background: rgba(16, 185, 129, 0.12);
+  color: #6ee7b7;
+  border-color: rgba(16, 185, 129, 0.18);
+}
+.badge-rose {
+  background: rgba(244, 63, 94, 0.1);
+  color: #e11d48;
+  border-color: rgba(244, 63, 94, 0.15);
+}
+.dark .badge-rose {
+  background: rgba(244, 63, 94, 0.12);
+  color: #fb7185;
+  border-color: rgba(244, 63, 94, 0.18);
+}
+.badge-amber {
+  background: rgba(245, 158, 11, 0.1);
+  color: #b45309;
+  border-color: rgba(245, 158, 11, 0.15);
+}
+.dark .badge-amber {
+  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
+  border-color: rgba(245, 158, 11, 0.18);
+}
+.badge-zinc {
+  background: rgba(113, 113, 122, 0.08);
+  color: #52525b;
+  border-color: rgba(113, 113, 122, 0.12);
+}
+.dark .badge-zinc {
+  background: rgba(161, 161, 170, 0.1);
+  color: #a1a1aa;
+  border-color: rgba(161, 161, 170, 0.15);
+}
+
+/* ── Status dots ── */
+.status-dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+.status-dot-lg {
+  width: 0.625rem;
+  height: 0.625rem;
+}
+.status-dot-success {
+  background: #10b981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+.status-dot-error {
+  background: #ef4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
+}
+.status-dot-warning {
+  background: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+}
+.status-dot-info {
+  background: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+.status-dot-neutral {
+  background: #a1a1aa;
+  box-shadow: 0 0 0 2px rgba(161, 161, 170, 0.2);
+}
+.status-dot-pulse {
+  animation: statusPulse 2s var(--ease-smooth) infinite;
+}
+
+/* ── Animations ── */
+@keyframes toastSlideIn {
+  from { opacity: 0; transform: translateY(-0.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes toastFadeOut {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-0.5rem); }
+}
+@keyframes txFadeOut {
+  to { opacity: 0; height: 0; padding: 0; border: none; overflow: hidden; }
+}
+@keyframes translateFade {
+  0%, 70% { opacity: 1; max-height: 4rem; padding: 0.75rem 1rem; margin: 0.35rem 0; }
+  100% { opacity: 0; max-height: 0; padding: 0; margin: 0; overflow: hidden; border: none; }
+}
+@keyframes highlightRow {
+  from { background: rgba(99, 102, 241, 0.08); }
+  to   { background: transparent; }
+}
+@keyframes statusPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(0.85); }
+}
+
+.toast { animation: toastSlideIn 0.25s var(--ease-smooth); }
+.toast.removing { animation: toastFadeOut 0.2s var(--ease-smooth) forwards; }
+.tx-row--moved { animation: txFadeOut 0.5s 0.3s var(--ease-smooth) forwards; }
+.translate-row-success { animation: translateFade 2s var(--ease-smooth) forwards; }
+.highlight-new { animation: highlightRow 1.5s var(--ease-smooth); }
+
+/* ── Scrollbar hide ── */
+.scrollbar-hide::-webkit-scrollbar { display: none; }
+.scrollbar-hide { scrollbar-width: none; }


### PR DESCRIPTION
## Summary
- **Settings dashboard** — HTMX-powered UI for managing providers, categories, and translations (`/providers`, `/categories`, `/translations`)
- **Custom design system** — Replaced Pico CSS CDN with a proper Tailwind CSS v4 build pipeline and hand-crafted component classes (indigo/zinc palette, frosted-glass header, SVG icons, nav pills, card system, badges, status dots)
- **WCAG AA dark mode** — Class-based dark mode with verified contrast ratios across all 15 template files. Minimum 6.3:1 for readable text on zinc-950 backgrounds
- **CSS build pipeline** — `@tailwindcss/cli` v4.2.1 with `bun run build:css` / `bun run dev:css` scripts. No CDN dependency

## Changes
- `src/web/styles.css` — 540-line design system (layout shell, buttons, cards, badges, status dots, forms, animations)
- `src/web/layout.ts` — Frosted-glass header, SVG sun/moon theme toggle, nav pill system
- `src/web/server.ts` — Static CSS serving via `Bun.file()` with cache headers
- `src/web/pages/*` — Three page templates with colored SVG section icons
- `src/web/partials/*` — 10 partials updated with indigo palette + dark mode contrast fixes
- `DESIGN_SYSTEM.md` — Complete design system reference
- `package.json` — Added `tailwindcss` + `@tailwindcss/cli` devDependencies

## Test plan
- [ ] `bun run build:css` completes without errors
- [ ] `bun run dev -- dashboard` starts server on port 3000
- [ ] `/providers`, `/categories`, `/translations` pages render correctly
- [ ] Dark mode toggle works (sun/moon SVG swap, localStorage persistence)
- [ ] All text readable in dark mode (no low-contrast zinc-500 text)
- [ ] `bun test` — all 190 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)