### PR TITLE
feat(cli): add non-blocking update check with 24h cache

### DIFF
--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -44,7 +44,7 @@ function getBinaryName(): string | null {
   return null;
 }
 
-async function fetchLatestRelease(): Promise<GithubRelease> {
+export async function fetchLatestRelease(): Promise<GithubRelease> {
   const res = await fetch(API_URL, {
     headers: { Accept: "application/vnd.github+json" },
   });
@@ -54,11 +54,11 @@ async function fetchLatestRelease(): Promise<GithubRelease> {
   return res.json() as Promise<GithubRelease>;
 }
 
-function parseVersion(tag: string): string {
+export function parseVersion(tag: string): string {
   return tag.replace(/^v/, "");
 }
 
-function isNewer(latest: string, current: string): boolean {
+export function isNewer(latest: string, current: string): boolean {
   const l = latest.split(".").map(Number);
   const c = current.split(".").map(Number);
   for (let i = 0; i < 3; i++) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,8 @@
 import { Command } from "commander";
 import { existsSync } from "fs";
 import { join } from "path";
-import { setOutputOptions, ExitCode, createSpinner, isInteractive } from "./output.js";
+import { setOutputOptions, setUpdateInfo, ExitCode, createSpinner, isInteractive } from "./output.js";
+import { checkForUpdate } from "./update-check.js";
 import { getAppPaths, ensureDirectories, getDbPath } from "../config/loader.js";
 import { initDatabase, closeDatabase } from "../db/database.js";
 import { registerInitCommand } from "./commands/init.js";
@@ -61,8 +62,24 @@ program
       nonInteractive: opts.nonInteractive,
     });
 
-    // Ensure data directories and init DB for commands that need it
+    // Check for available updates (cached, non-blocking)
     const commandName = actionCommand.name();
+    if (commandName !== "update") {
+      const updateInfo = checkForUpdate();
+      if (updateInfo) {
+        setUpdateInfo(updateInfo);
+        // Human-mode notice via exit handler (fires even with process.exit)
+        if (!opts.json && !opts.quiet) {
+          process.on("exit", () => {
+            const msg = `\nUpdate available: v${updateInfo.current} \u2192 v${updateInfo.latest}`
+              + `\nRun "kolshek update" to install.`;
+            console.error(msg);
+          });
+        }
+      }
+    }
+
+    // Ensure data directories and init DB for commands that need it
     if (commandName !== "init" && commandName !== "update") {
       await ensureDirectories();
       const dbPath = getDbPath();

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -41,6 +41,17 @@ let _opts: OutputOptions = {
   nonInteractive: false,
 };
 
+// Update-available state (set from preAction via checkForUpdate)
+let _updateInfo: { latest: string; current: string } | null = null;
+
+export function setUpdateInfo(info: { latest: string; current: string } | null): void {
+  _updateInfo = info;
+}
+
+export function getUpdateInfo(): { latest: string; current: string } | null {
+  return _updateInfo;
+}
+
 export function setOutputOptions(opts: Partial<OutputOptions>): void {
   _opts = { ..._opts, ...opts };
   // Apply environment-based overrides
@@ -73,10 +84,16 @@ export function isInteractive(): boolean {
 // JSON envelope
 // ---------------------------------------------------------------------------
 
+interface JsonMetadata {
+  timestamp: string;
+  version: string;
+  updateAvailable?: { latest: string; current: string };
+}
+
 interface JsonSuccess<T = unknown> {
   success: true;
   data: T;
-  metadata: { timestamp: string; version: string };
+  metadata: JsonMetadata;
 }
 
 interface JsonError {
@@ -88,13 +105,17 @@ interface JsonError {
     retryable: boolean;
     suggestions: string[];
   };
-  metadata: { timestamp: string; version: string };
+  metadata: JsonMetadata;
 }
 
 import pkg from "../../package.json";
 
-function meta(): { timestamp: string; version: string } {
-  return { timestamp: new Date().toISOString(), version: pkg.version };
+function meta(): JsonMetadata {
+  const m: JsonMetadata = { timestamp: new Date().toISOString(), version: pkg.version };
+  if (_updateInfo) {
+    m.updateAvailable = _updateInfo;
+  }
+  return m;
 }
 
 export function jsonSuccess<T>(data: T): JsonSuccess<T> {

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -1,0 +1,74 @@
+// Passive update-availability check with 24h file cache.
+// Never blocks CLI execution. All errors silently swallowed.
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { getAppPaths } from "../config/loader.js";
+import { fetchLatestRelease, parseVersion, isNewer } from "./commands/update.js";
+import pkg from "../../package.json";
+
+interface UpdateCache {
+  latestVersion: string;
+  checkedAt: string;
+}
+
+const STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getCachePath(): string {
+  return join(getAppPaths().cache, "update-check.json");
+}
+
+function readCache(): UpdateCache | null {
+  try {
+    const raw = readFileSync(getCachePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.latestVersion === "string" && typeof parsed.checkedAt === "string") {
+      return parsed as UpdateCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isCacheStale(cache: UpdateCache | null): boolean {
+  if (!cache) return true;
+  const age = Date.now() - new Date(cache.checkedAt).getTime();
+  return age > STALE_MS || age < 0;
+}
+
+// Fire-and-forget GitHub API check. Writes cache for next invocation.
+export function refreshUpdateCacheInBackground(): void {
+  fetchLatestRelease()
+    .then((release) => {
+      const latestVersion = parseVersion(release.tag_name);
+      const cachePath = getCachePath();
+      try {
+        mkdirSync(dirname(cachePath), { recursive: true });
+      } catch {
+        // already exists
+      }
+      const data: UpdateCache = { latestVersion, checkedAt: new Date().toISOString() };
+      writeFileSync(cachePath, JSON.stringify(data));
+    })
+    .catch(() => {
+      // Silent — never interrupt the CLI for update checks
+    });
+}
+
+// Main entry point. Sync cache read, optional background refresh.
+// Returns update info if a newer version exists, null otherwise.
+export function checkForUpdate(): { latest: string; current: string } | null {
+  try {
+    const cache = readCache();
+    if (isCacheStale(cache)) {
+      refreshUpdateCacheInBackground();
+    }
+    if (cache && isNewer(cache.latestVersion, pkg.version)) {
+      return { latest: cache.latestVersion, current: pkg.version };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -27,6 +27,7 @@ export async function ensureDirectories(): Promise<void> {
   await Promise.all([
     mkdir(paths.config, { recursive: true, mode }),
     mkdir(paths.data, { recursive: true, mode }),
+    mkdir(paths.cache, { recursive: true, mode }),
   ]);
   // On Windows, chmod is a no-op — use icacls to restrict directory access
   restrictPathToOwner(paths.config);


### PR DESCRIPTION
## Summary

- Adds passive background update checking that never blocks CLI execution
- Caches update availability for 24 hours to reduce GitHub API calls
- Displays update notifications in CLI output and JSON metadata
- All errors during update checks are silently swallowed to ensure reliability

## Changes

### New `update-check.ts` module
- Implements sync cache read with optional background refresh
- Checks GitHub API only when cache is stale (24h TTL)
- Returns update info if a newer version exists
- Uses fire-and-forget pattern for API calls to avoid blocking

### Integration in CLI initialization
- Calls `checkForUpdate()` before executing commands (except `update` itself)
- Shows human-friendly update notice via exit handler for non-JSON/non-quiet modes
- Includes update info in JSON metadata when available

### JSON API enhancement
- Extended metadata to include `updateAvailable` field with current and latest versions
- Allows programmatic tools to detect and handle updates

### Minor refactoring
- Exported helper functions (`fetchLatestRelease`, `parseVersion`, `isNewer`) from update command for reuse
- Added cache directory creation in config loader

## Technical Details

The update check uses a 24-hour file-based cache to balance freshness and API efficiency. On first run or after cache expires, a background promise fetches the latest release from GitHub and updates the cache. The synchronous cache read ensures instant CLI responsiveness regardless of API availability.