### PR TITLE
feat(dashboard): per-provider sync, queuing, and auth update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ package-lock.json
 # Environment / secrets
 .env
 .env.*
+.dev-session
 
 # OS
 .DS_Store

--- a/src/web/app/app.tsx
+++ b/src/web/app/app.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "./hooks/use-theme";
+import { useTokenAuth } from "./hooks/use-token-auth";
 import { AppShell } from "./components/layout/app-shell";
 import { ErrorBoundary } from "./components/shared/error-boundary";
 import { DashboardPage } from "./pages/dashboard-page";
@@ -22,6 +23,9 @@ const queryClient = new QueryClient({
 });
 
 export function App() {
+  // Exchange ?token= for a session cookie via API (works through Vite proxy in dev)
+  useTokenAuth();
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>

--- a/src/web/app/components/layout/sync-panel.tsx
+++ b/src/web/app/components/layout/sync-panel.tsx
@@ -259,7 +259,11 @@ export function SyncPanel({
         {isDone && (
           <div className="pt-4 border-t space-y-3">
             <div className="text-sm text-center">
-              {totals.added === 0 && totals.updated === 0 ? (
+              {hasErrors ? (
+                <span className="text-destructive">
+                  Some providers failed to sync
+                </span>
+              ) : totals.added === 0 && totals.updated === 0 ? (
                 <span className="text-muted-foreground">
                   Everything is up to date
                 </span>

--- a/src/web/app/components/layout/sync-panel.tsx
+++ b/src/web/app/components/layout/sync-panel.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircle2,
   XCircle,
   Loader2,
+  Clock,
 } from "lucide-react";
 import {
   Sheet,
@@ -33,7 +34,7 @@ interface ProviderStatus {
   name: string;
   stage: string;
   progress: number; // 0-100
-  status: "running" | "done" | "error";
+  status: "queued" | "running" | "done" | "error";
   added: number;
   updated: number;
   error: string | null;
@@ -54,20 +55,43 @@ function deriveProviderStatuses(events: SyncEvent[]): ProviderStatus[] {
   const map = new Map<string, ProviderStatus>();
 
   for (const evt of events) {
-    // "start" event initializes all providers so they appear immediately
-    if (evt.type === "start" && evt.providers) {
+    // "queued" event shows providers waiting for the current sync to finish
+    if (evt.type === "queued" && evt.providers) {
       for (const name of evt.providers) {
         if (!map.has(name)) {
           map.set(name, {
             name,
-            stage: "connecting...",
+            stage: "queued",
             progress: 0,
-            status: "running",
+            status: "queued",
             added: 0,
             updated: 0,
             error: null,
           });
         }
+      }
+      continue;
+    }
+
+    // "start" event initializes all providers so they appear immediately
+    if (evt.type === "start" && evt.providers) {
+      for (const name of evt.providers) {
+        // Remove any queued entry that matches (case-insensitive) —
+        // the queued name may be the displayName while the server uses the alias
+        for (const [key, val] of map) {
+          if (val.status === "queued" && key.toLowerCase() === name.toLowerCase()) {
+            map.delete(key);
+          }
+        }
+        map.set(name, {
+          name,
+          stage: "connecting...",
+          progress: 0,
+          status: "running",
+          added: 0,
+          updated: 0,
+          error: null,
+        });
       }
       continue;
     }
@@ -122,6 +146,9 @@ function ProviderRow({ provider }: { provider: ProviderStatus }) {
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{provider.name}</span>
         <div className="flex items-center gap-1.5">
+          {provider.status === "queued" && (
+            <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
           {provider.status === "running" && (
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
           )}

--- a/src/web/app/components/providers/provider-grid.tsx
+++ b/src/web/app/components/providers/provider-grid.tsx
@@ -142,14 +142,14 @@ function ProviderCardItem({
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 onClick={() => onSync({ providerId: provider.id })}
-                disabled={isSyncing || !provider.hasCredentials}
+                disabled={!provider.hasCredentials}
               >
                 <RefreshCw className="h-4 w-4" />
                 Sync
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => onSync({ providerId: provider.id, visible: true })}
-                disabled={isSyncing || !provider.hasCredentials}
+                disabled={!provider.hasCredentials}
               >
                 <Eye className="h-4 w-4" />
                 Sync (visible)

--- a/src/web/app/components/providers/provider-grid.tsx
+++ b/src/web/app/components/providers/provider-grid.tsx
@@ -8,6 +8,8 @@ import {
   KeyRound,
   Trash2,
   MoreVertical,
+  RefreshCw,
+  Eye,
 } from "lucide-react";
 import {
   Card,
@@ -40,9 +42,10 @@ import type { ProviderCard as ProviderCardType } from "@/types/api";
 
 interface ProviderGridProps {
   providers: ProviderCardType[];
-  onSync: () => void;
+  onSync: (options?: { providerId?: number; visible?: boolean }) => void;
   onDelete: (id: number) => void;
   onAuth: (id: number) => void;
+  isSyncing?: boolean;
 }
 
 // Confirmation dialog for provider deletion
@@ -89,10 +92,14 @@ function ProviderCardItem({
   provider,
   onAuth,
   onDeleteRequest,
+  onSync,
+  isSyncing,
 }: {
   provider: ProviderCardType;
   onAuth: (id: number) => void;
   onDeleteRequest: (provider: ProviderCardType) => void;
+  onSync: (options?: { providerId?: number; visible?: boolean }) => void;
+  isSyncing?: boolean;
 }) {
   const Icon = provider.type === "bank" ? Building2 : CreditCard;
 
@@ -133,6 +140,21 @@ function ProviderCardItem({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => onSync({ providerId: provider.id })}
+                disabled={isSyncing || !provider.hasCredentials}
+              >
+                <RefreshCw className="h-4 w-4" />
+                Sync
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onSync({ providerId: provider.id, visible: true })}
+                disabled={isSyncing || !provider.hasCredentials}
+              >
+                <Eye className="h-4 w-4" />
+                Sync (visible)
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => onAuth(provider.id)}>
                 <KeyRound className="h-4 w-4" />
                 Update Auth
@@ -194,9 +216,10 @@ function ProviderCardItem({
 
 export function ProviderGrid({
   providers,
-  onSync: _onSync,
+  onSync,
   onDelete,
   onAuth,
+  isSyncing,
 }: ProviderGridProps) {
   const [deleteTarget, setDeleteTarget] = useState<ProviderCardType | null>(
     null
@@ -218,6 +241,8 @@ export function ProviderGrid({
             provider={provider}
             onAuth={onAuth}
             onDeleteRequest={setDeleteTarget}
+            onSync={onSync}
+            isSyncing={isSyncing}
           />
         ))}
       </div>

--- a/src/web/app/components/providers/update-auth-dialog.tsx
+++ b/src/web/app/components/providers/update-auth-dialog.tsx
@@ -1,0 +1,162 @@
+// Dialog for updating a provider's credentials
+import { useState, useCallback } from "react";
+import { Loader2, ShieldCheck } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert } from "@/components/ui/alert";
+import { useProviderFields, useUpdateAuth } from "@/hooks/use-providers";
+import type { ProviderCard } from "@/types/api";
+
+// Human-readable field name from API field key
+const FIELD_LABELS: Record<string, string> = {
+  username: "Username",
+  userCode: "User Code",
+  password: "Password",
+  id: "ID Number",
+  num: "Card Number",
+  nationalID: "National ID",
+  card5Digits: "Last 5 Digits",
+  card6Digits: "Last 6 Digits",
+  otpCodeReturnRecipient: "OTP Code Return Recipient",
+};
+
+const PASSWORD_FIELDS = new Set(["password", "nationalID", "id"]);
+
+interface UpdateAuthDialogProps {
+  provider: ProviderCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function UpdateAuthDialog({
+  provider,
+  open,
+  onOpenChange,
+}: UpdateAuthDialogProps) {
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const updateAuth = useUpdateAuth();
+
+  const { data: fieldsData, isLoading: fieldsLoading } = useProviderFields(
+    provider?.companyId ?? ""
+  );
+  const loginFields = fieldsData?.loginFields ?? [];
+
+  const allFilled = loginFields.every(
+    (f) => credentials[f] && credentials[f].trim() !== ""
+  );
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        setTimeout(() => {
+          setCredentials({});
+          updateAuth.reset();
+        }, 200);
+      }
+      onOpenChange(isOpen);
+    },
+    [onOpenChange, updateAuth]
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!provider || !allFilled) return;
+    updateAuth.mutate(
+      { id: provider.id, credentials },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  }, [provider, allFilled, credentials, updateAuth, handleOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Update Credentials</DialogTitle>
+          <DialogDescription>
+            Enter new login credentials for{" "}
+            <span className="font-medium">{provider?.displayName}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <Alert className="flex items-start gap-2 border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
+            <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <p className="text-xs">
+              Credentials are stored securely in your system keychain and are
+              never transmitted to external servers.
+            </p>
+          </Alert>
+
+          {fieldsLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : loginFields.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No credential fields found for this provider.
+            </p>
+          ) : (
+            loginFields.map((field) => (
+              <div key={field} className="space-y-1.5">
+                <Label htmlFor={`auth-${field}`}>
+                  {FIELD_LABELS[field] ||
+                    field.charAt(0).toUpperCase() + field.slice(1)}
+                </Label>
+                <Input
+                  id={`auth-${field}`}
+                  type={PASSWORD_FIELDS.has(field) ? "password" : "text"}
+                  value={credentials[field] || ""}
+                  onChange={(e) =>
+                    setCredentials((prev) => ({
+                      ...prev,
+                      [field]: e.target.value,
+                    }))
+                  }
+                  autoComplete="off"
+                />
+              </div>
+            ))
+          )}
+
+          {updateAuth.isError && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3">
+              <p className="text-sm text-destructive">
+                {updateAuth.error instanceof Error
+                  ? updateAuth.error.message
+                  : "Failed to update credentials"}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button
+            onClick={handleSubmit}
+            disabled={!allFilled || updateAuth.isPending}
+          >
+            {updateAuth.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save Credentials"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/web/app/hooks/use-sync.ts
+++ b/src/web/app/hooks/use-sync.ts
@@ -22,7 +22,7 @@ export function useSync() {
   const abortRef = useRef<AbortController | null>(null);
   const queryClient = useQueryClient();
 
-  const start = useCallback(async (visible?: boolean) => {
+  const start = useCallback(async (options?: { visible?: boolean; providers?: number[] }) => {
     // Prevent double-start
     if (abortRef.current) {
       abortRef.current.abort();
@@ -35,12 +35,15 @@ export function useSync() {
     setIsRunning(true);
 
     try {
-      const body = visible !== undefined ? { visible } : undefined;
+      const body: Record<string, unknown> = {};
+      if (options?.visible) body.visible = true;
+      if (options?.providers?.length) body.providers = options.providers;
+      const hasBody = Object.keys(body).length > 0;
       const res = await fetch("/api/v2/fetch", {
         method: "POST",
         credentials: "include",
-        headers: body ? { "Content-Type": "application/json" } : {},
-        body: body ? JSON.stringify(body) : undefined,
+        headers: hasBody ? { "Content-Type": "application/json" } : {},
+        body: hasBody ? JSON.stringify(body) : undefined,
         signal: controller.signal,
       });
 

--- a/src/web/app/hooks/use-sync.ts
+++ b/src/web/app/hooks/use-sync.ts
@@ -1,7 +1,16 @@
-// Sync hook — streams SSE events from the fetch endpoint
+// Sync hook — streams SSE events from the fetch endpoint.
+// Supports queuing: if a sync is in progress and start() is called again,
+// the new providers are queued and run automatically after the current sync.
 import { useState, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { SyncEvent } from "@/types/api";
+
+interface SyncOptions {
+  visible?: boolean;
+  providers?: number[];
+  // Display names for the queued providers (used in sync panel)
+  providerNames?: string[];
+}
 
 // Parse a single SSE "data: {...}" line into a SyncEvent
 function parseSseEvent(line: string): SyncEvent | null {
@@ -20,19 +29,14 @@ export function useSync() {
   const [events, setEvents] = useState<SyncEvent[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const queueRef = useRef<SyncOptions[]>([]);
+  const runningRef = useRef(false);
   const queryClient = useQueryClient();
 
-  const start = useCallback(async (options?: { visible?: boolean; providers?: number[] }) => {
-    // Prevent double-start
-    if (abortRef.current) {
-      abortRef.current.abort();
-    }
-
+  // Internal: run a single sync batch (no queuing logic)
+  const runSync = useCallback(async (options?: SyncOptions) => {
     const controller = new AbortController();
     abortRef.current = controller;
-
-    setEvents([]);
-    setIsRunning(true);
 
     try {
       const body: Record<string, unknown> = {};
@@ -53,7 +57,6 @@ export function useSync() {
           ...prev,
           { type: "error", error: text || "Fetch failed" },
         ]);
-        setIsRunning(false);
         return;
       }
 
@@ -69,31 +72,31 @@ export function useSync() {
 
         // SSE events are separated by double newlines
         const parts = buffer.split("\n\n");
-        // Keep the last incomplete chunk in the buffer
         buffer = parts.pop() || "";
 
         for (const part of parts) {
-          // Each part may have multiple lines (event:, data:, etc.)
           for (const line of part.split("\n")) {
             const event = parseSseEvent(line);
             if (event) {
+              // Filter out "done" events from intermediate batches —
+              // we emit our own final "done" after all queued syncs complete
+              if (event.type === "done" && queueRef.current.length > 0) continue;
               setEvents((prev) => [...prev, event]);
             }
           }
         }
       }
 
-      // Process any remaining buffer
       if (buffer.trim()) {
         for (const line of buffer.split("\n")) {
           const event = parseSseEvent(line);
           if (event) {
+            if (event.type === "done" && queueRef.current.length > 0) continue;
             setEvents((prev) => [...prev, event]);
           }
         }
       }
     } catch (err: unknown) {
-      // Ignore abort errors
       if (err instanceof DOMException && err.name === "AbortError") {
         return;
       }
@@ -101,12 +104,53 @@ export function useSync() {
         err instanceof Error ? err.message : "Unknown sync error";
       setEvents((prev) => [...prev, { type: "error", error: message }]);
     } finally {
-      setIsRunning(false);
       abortRef.current = null;
-      // Invalidate all cached queries so the dashboard shows fresh data
-      queryClient.invalidateQueries();
     }
-  }, [queryClient]);
+  }, []);
+
+  // Process the queue: run syncs one by one until the queue is empty
+  const processQueue = useCallback(async (initial: SyncOptions | undefined) => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setIsRunning(true);
+
+    // Run the initial sync
+    await runSync(initial);
+
+    // Drain the queue
+    while (queueRef.current.length > 0) {
+      const next = queueRef.current.shift()!;
+      // Remove the "queued" events for providers that are about to start
+      // (they'll get real "start"/"progress" events from the server)
+      await runSync(next);
+    }
+
+    runningRef.current = false;
+    setIsRunning(false);
+    queryClient.invalidateQueries();
+  }, [runSync, queryClient]);
+
+  const start = useCallback((options?: SyncOptions) => {
+    if (runningRef.current) {
+      // Already syncing — queue this request and show queued status
+      queueRef.current.push(options ?? {});
+      // Add synthetic "queued" events so the panel shows them
+      const names = options?.providerNames ?? options?.providers?.map(String);
+      setEvents((prev) => [
+        ...prev,
+        {
+          type: "queued",
+          providers: names,
+          message: names ? undefined : "All providers queued",
+        },
+      ]);
+      return;
+    }
+
+    // Fresh sync — clear previous events
+    setEvents([]);
+    processQueue(options);
+  }, [processQueue]);
 
   return { events, isRunning, start };
 }

--- a/src/web/app/hooks/use-token-auth.ts
+++ b/src/web/app/hooks/use-token-auth.ts
@@ -1,0 +1,36 @@
+// Handles ?token= query param authentication via API.
+// In production, the server does a redirect to set the cookie.
+// In dev mode (Vite proxy on :5173), we exchange the token via
+// POST /api/v2/auth/token so the cookie is set on the Vite origin.
+import { useEffect, useRef } from "react";
+
+export function useTokenAuth() {
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+    if (!token) return;
+
+    attempted.current = true;
+
+    fetch("/api/v2/auth/token", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    })
+      .then((res) => {
+        if (res.ok) {
+          // Remove the token from the URL without a page reload
+          params.delete("token");
+          const clean = window.location.pathname + (params.toString() ? `?${params}` : "");
+          window.history.replaceState({}, "", clean);
+        }
+      })
+      .catch(() => {
+        // Silently ignore — the redirect flow is the fallback
+      });
+  }, []);
+}

--- a/src/web/app/pages/providers-page.tsx
+++ b/src/web/app/pages/providers-page.tsx
@@ -9,13 +9,14 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { ProviderGrid } from "@/components/providers/provider-grid";
 import { AddProviderWizard } from "@/components/providers/add-provider-wizard";
 import { SyncPanel } from "@/components/layout/sync-panel";
+import { UpdateAuthDialog } from "@/components/providers/update-auth-dialog";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
-import { useProviders, useDeleteProvider, useUpdateAuth } from "@/hooks/use-providers";
+import { useProviders, useDeleteProvider } from "@/hooks/use-providers";
 import { useSync } from "@/hooks/use-sync";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -23,13 +24,11 @@ export function ProvidersPage() {
   useDocumentTitle("Providers");
   const { data: providers, isLoading, isError, error } = useProviders();
   const deleteProvider = useDeleteProvider();
-  const updateAuth = useUpdateAuth();
   const { events, isRunning, start } = useSync();
 
   const [wizardOpen, setWizardOpen] = useState(false);
   const [syncPanelOpen, setSyncPanelOpen] = useState(false);
-  // Track which provider is being re-authed (for future inline auth modal)
-  const [_authTarget, setAuthTarget] = useState<number | null>(null);
+  const [authTarget, setAuthTarget] = useState<number | null>(null);
 
   const handleSync = useCallback((options?: { providerId?: number; visible?: boolean }) => {
     setSyncPanelOpen(true);
@@ -46,17 +45,9 @@ export function ProvidersPage() {
     [deleteProvider]
   );
 
-  const handleAuth = useCallback(
-    (id: number) => {
-      // For now, open the wizard or an auth dialog
-      // This is a placeholder — a full auth update flow could be its own modal
-      setAuthTarget(id);
-      // TODO: Open dedicated auth-update dialog
-      // For now we signal intent via console (the grid card action works)
-      void updateAuth;
-    },
-    [updateAuth]
-  );
+  const handleAuth = useCallback((id: number) => {
+    setAuthTarget(id);
+  }, []);
 
   const handleRetrySync = useCallback(() => {
     start();
@@ -164,6 +155,15 @@ export function ProvidersPage() {
           {isRunning ? "Syncing..." : "Sync Results"}
         </Button>
       )}
+
+      {/* Update auth dialog */}
+      <UpdateAuthDialog
+        provider={providers?.find((p) => p.id === authTarget) ?? null}
+        open={authTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setAuthTarget(null);
+        }}
+      />
 
       {/* Add provider wizard */}
       <AddProviderWizard open={wizardOpen} onOpenChange={setWizardOpen} />

--- a/src/web/app/pages/providers-page.tsx
+++ b/src/web/app/pages/providers-page.tsx
@@ -1,7 +1,7 @@
 // Providers management page — grid of connected providers with sync and
 // add-connection wizard
 import { useState, useCallback } from "react";
-import { Plus, Unplug, RefreshCw } from "lucide-react";
+import { Plus, Unplug, RefreshCw, ChevronDown, Eye } from "lucide-react";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
@@ -9,6 +9,12 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { ProviderGrid } from "@/components/providers/provider-grid";
 import { AddProviderWizard } from "@/components/providers/add-provider-wizard";
 import { SyncPanel } from "@/components/layout/sync-panel";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { useProviders, useDeleteProvider, useUpdateAuth } from "@/hooks/use-providers";
 import { useSync } from "@/hooks/use-sync";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,9 +31,12 @@ export function ProvidersPage() {
   // Track which provider is being re-authed (for future inline auth modal)
   const [_authTarget, setAuthTarget] = useState<number | null>(null);
 
-  const handleSync = useCallback(() => {
+  const handleSync = useCallback((options?: { providerId?: number; visible?: boolean }) => {
     setSyncPanelOpen(true);
-    start();
+    start({
+      providers: options?.providerId ? [options.providerId] : undefined,
+      visible: options?.visible,
+    });
   }, [start]);
 
   const handleDelete = useCallback(
@@ -59,15 +68,36 @@ export function ProvidersPage() {
         title="Connections"
         description="Manage your bank and credit card connections."
       >
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleSync}
-          disabled={isRunning || !providers?.length}
-        >
-          <RefreshCw className={isRunning ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
-          Sync All
-        </Button>
+        <div className="flex items-center">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleSync()}
+            disabled={isRunning || !providers?.length}
+            className="rounded-r-none"
+          >
+            <RefreshCw className={isRunning ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+            Sync All
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isRunning || !providers?.length}
+                className="rounded-l-none border-l-0 px-1.5"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => handleSync({ visible: true })}>
+                <Eye className="h-4 w-4" />
+                Sync All (visible)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         <Button size="sm" onClick={() => setWizardOpen(true)}>
           <Plus className="h-4 w-4" />
           Add Connection
@@ -118,7 +148,21 @@ export function ProvidersPage() {
           onSync={handleSync}
           onDelete={handleDelete}
           onAuth={handleAuth}
+          isSyncing={isRunning}
         />
+      )}
+
+      {/* Reopen sync panel when closed but sync data exists */}
+      {!syncPanelOpen && events.length > 0 && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="fixed bottom-4 right-4 z-50 shadow-md"
+          onClick={() => setSyncPanelOpen(true)}
+        >
+          <RefreshCw className={isRunning ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+          {isRunning ? "Syncing..." : "Sync Results"}
+        </Button>
       )}
 
       {/* Add provider wizard */}

--- a/src/web/app/pages/providers-page.tsx
+++ b/src/web/app/pages/providers-page.tsx
@@ -32,11 +32,15 @@ export function ProvidersPage() {
 
   const handleSync = useCallback((options?: { providerId?: number; visible?: boolean }) => {
     setSyncPanelOpen(true);
+    const provider = options?.providerId
+      ? providers?.find((p) => p.id === options.providerId)
+      : undefined;
     start({
       providers: options?.providerId ? [options.providerId] : undefined,
+      providerNames: provider ? [provider.displayName] : undefined,
       visible: options?.visible,
     });
-  }, [start]);
+  }, [start, providers]);
 
   const handleDelete = useCallback(
     (id: number) => {

--- a/src/web/app/types/api.ts
+++ b/src/web/app/types/api.ts
@@ -215,7 +215,7 @@ export interface Insight {
 }
 
 export interface SyncEvent {
-  type: "start" | "progress" | "result" | "error" | "done";
+  type: "start" | "progress" | "result" | "error" | "done" | "queued";
   provider?: string;
   providers?: string[];
   stage?: string;

--- a/src/web/app/vite.config.ts
+++ b/src/web/app/vite.config.ts
@@ -2,6 +2,22 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import fs from "node:fs";
+
+// Read session cookie from .dev-session (written by the dashboard server).
+// This lets the Vite proxy authenticate API requests without the browser
+// needing to exchange a token first.
+function readDevSession(): string | null {
+  try {
+    const content = fs.readFileSync(
+      path.resolve(__dirname, "../../../.dev-session"),
+      "utf-8",
+    ).trim();
+    return content || null;
+  } catch {
+    return null;
+  }
+}
 
 export default defineConfig({
   root: path.resolve(__dirname),
@@ -18,7 +34,19 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/api": "http://127.0.0.1:3000",
+      "/api": {
+        target: "http://127.0.0.1:3000",
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq) => {
+            // Inject the session cookie so API requests are authenticated
+            const session = readDevSession();
+            if (session) {
+              const existing = proxyReq.getHeader("cookie") as string | undefined;
+              proxyReq.setHeader("cookie", existing ? `${existing}; ${session}` : session);
+            }
+          });
+        },
+      },
     },
   },
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -239,6 +239,15 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
   const sessionToken = randomBytes(32).toString("hex");
   const cookieName = "kolshek_session";
 
+  // Write session token to .dev-session so the Vite dev proxy can inject it.
+  // This file is gitignored and only used for local development.
+  try {
+    const devSessionPath = resolve(import.meta.dir, "../../.dev-session");
+    Bun.write(devSessionPath, `${cookieName}=${sessionToken}`);
+  } catch {
+    // Non-fatal — only needed for Vite dev mode
+  }
+
   // Parse the session cookie from a Cookie header
   function getSessionCookie(req: Request): string | null {
     const cookies = req.headers.get("cookie") ?? "";
@@ -283,6 +292,27 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
       }
 
       // --- Authentication ---
+
+      // POST /api/v2/auth/token — exchange a token for a session cookie.
+      // This endpoint is unauthenticated so the Vite dev server (port 5173)
+      // can proxy it and set the cookie on its own origin.
+      if (method === "POST" && path === "/api/v2/auth/token") {
+        const body = await parseJsonBody(req);
+        const token = typeof body.token === "string" ? body.token : "";
+        if (token !== sessionToken) {
+          return jsonError("UNAUTHORIZED", "Invalid token.", 401);
+        }
+        return new Response(JSON.stringify({ success: true, data: null }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Set-Cookie": sessionCookieHeader(),
+            ...SECURITY_HEADERS,
+            ...cors,
+          },
+        });
+      }
+
       // If the request has ?token= in the URL, validate it and set a cookie.
       // This is the initial browser open from the CLI.
       if (url.searchParams.has("token")) {
@@ -1049,7 +1079,8 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
           }
           const body = await parseJsonBody(req);
           const visible = body.visible === true || body.visible === 1;
-          return startFetchSSE(visible, jsonError);
+          const providerIds = Array.isArray(body.providers) ? (body.providers as number[]) : undefined;
+          return startFetchSSE(visible, providerIds, jsonError);
         }
 
         // GET /api/v2/fetch/events — SSE stream for fetch progress
@@ -1106,7 +1137,7 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
 
 // --- SSE Helpers ---
 
-function startFetchSSE(visible: boolean, jsonError: JsonErrorFn): Response {
+function startFetchSSE(visible: boolean, providerIds: number[] | undefined, jsonError: JsonErrorFn): Response {
   const events: string[] = [];
   const listeners: Set<(event: string) => void> = new Set();
 
@@ -1115,10 +1146,13 @@ function startFetchSSE(visible: boolean, jsonError: JsonErrorFn): Response {
     for (const listener of listeners) listener(data);
   }
 
-  // Start fetch in background
-  const providers = listProviders();
+  // Start fetch in background — optionally filter to specific providers
+  const allProviders = listProviders();
+  const providers = providerIds
+    ? allProviders.filter((p) => providerIds.includes(p.id))
+    : allProviders;
   if (providers.length === 0) {
-    return jsonError("NO_PROVIDERS", "No providers configured.", 400);
+    return jsonError("NO_PROVIDERS", providerIds ? "No matching providers found." : "No providers configured.", 400);
   }
 
   pushEvent(


### PR DESCRIPTION
## Summary
- **Per-provider sync**: Each provider card now has Sync and Sync (visible) options in its dropdown menu, allowing syncing individual providers instead of only "Sync All"
- **Sync queuing**: Clicking sync on another provider while one is already syncing queues it automatically — the sync panel shows queued providers with a clock icon and processes them in order
- **Visible sync toggle**: "Sync All" button split into a dropdown with a "Sync All (visible)" option for OTP/2FA flows
- **Update Auth dialog**: The "Update Auth" dropdown action now opens a credentials dialog with dynamic login fields fetched from the API
- **Dev mode auth**: Added `POST /api/v2/auth/token` endpoint and Vite proxy session injection (`.dev-session` file) so the dashboard works through Vite's dev server on port 5173
- **Sync panel UX**: Floating "Sync Results" button to reopen the panel after closing; error summary replaces "Everything is up to date" when providers fail

## Test plan
- [ ] Providers page → card dropdown → "Sync" syncs only that provider
- [ ] "Sync (visible)" opens browser window for OTP
- [ ] Sync provider A, then sync provider B while A runs → B shows as "queued", then auto-starts
- [ ] Queued provider row disappears when it starts syncing (no duplicates)
- [ ] "Update Auth" opens dialog with correct fields, saves credentials
- [ ] "Sync All" and "Sync All (visible)" still work
- [ ] Close sync panel → floating button appears → click to reopen
- [ ] Failed providers show "Some providers failed to sync" instead of "Everything is up to date"
- [ ] Dev mode: `bun run dev -- dashboard` + `bun run dev:web` → port 5173 can access API

🤖 Generated with [Claude Code](https://claude.com/claude-code)