### PR TITLE
fix(installer): replace pluginDirs with marketplace registration

### DIFF
--- a/plugin/scripts/install.sh
+++ b/plugin/scripts/install.sh
@@ -54,16 +54,61 @@ get_frontmatter() {
 
 # --- Claude Code ---
 install_claude_code() {
-  local dest="${HOME}/.claude/plugins/kolshek"
-  mkdir -p "$dest"
-  cp -r "$PLUGIN_DIR/.claude-plugin" "$dest/" 2>&1 || true
-  cp -r "$PLUGIN_DIR/skills" "$dest/" 2>&1 || true
-  cp -r "$PLUGIN_DIR/hooks" "$dest/" 2>&1 || true
-  cp -r "$PLUGIN_DIR/references" "$dest/" 2>&1 || true
-  mkdir -p "$dest/scripts"
-  cp "$PLUGIN_DIR/scripts/check-config.sh" "$dest/scripts/" 2>&1 || true
-  info "Claude Code: plugin installed -> $dest"
-  echo "  Ensure ~/.claude/settings.json has: \"pluginDirs\": [\"$dest\"]"
+  local marketplace_dir="${HOME}/.claude/plugins/kolshek"
+  local plugin_dir="${marketplace_dir}/kolshek"
+  mkdir -p "$plugin_dir"
+
+  # Copy plugin files into nested kolshek/ subdirectory
+  cp -r "$PLUGIN_DIR/.claude-plugin" "$plugin_dir/" 2>&1 || true
+  cp -r "$PLUGIN_DIR/skills" "$plugin_dir/" 2>&1 || true
+  cp -r "$PLUGIN_DIR/hooks" "$plugin_dir/" 2>&1 || true
+  cp -r "$PLUGIN_DIR/references" "$plugin_dir/" 2>&1 || true
+  mkdir -p "$plugin_dir/scripts"
+  cp "$PLUGIN_DIR/scripts/check-config.sh" "$plugin_dir/scripts/" 2>&1 || true
+
+  # Write marketplace manifest at marketplace root
+  mkdir -p "$marketplace_dir/.claude-plugin"
+  cat > "$marketplace_dir/.claude-plugin/marketplace.json" <<'MANIFEST'
+{
+  "name": "kolshek-local",
+  "owner": { "name": "KolShek" },
+  "plugins": [
+    {
+      "name": "kolshek",
+      "source": "./kolshek",
+      "description": "KolShek — Israeli finance CLI plugin for Claude Code"
+    }
+  ]
+}
+MANIFEST
+
+  info "Claude Code: plugin installed -> $marketplace_dir"
+
+  # Auto-register in ~/.claude/settings.json
+  local settings_file="${HOME}/.claude/settings.json"
+  if command -v jq >/dev/null 2>&1; then
+    local tmp_settings
+    tmp_settings="$(mktemp)"
+    if [ -f "$settings_file" ]; then
+      jq --arg dir "$marketplace_dir" '
+        .extraKnownMarketplaces["kolshek-local"] = {source: {source: "directory", path: $dir}} |
+        .enabledPlugins["kolshek@kolshek-local"] = true
+      ' "$settings_file" > "$tmp_settings" && mv "$tmp_settings" "$settings_file"
+      info "Registered plugin in $settings_file"
+    else
+      mkdir -p "$(dirname "$settings_file")"
+      jq -n --arg dir "$marketplace_dir" '{
+        extraKnownMarketplaces: {"kolshek-local": {source: {source: "directory", path: $dir}}},
+        enabledPlugins: {"kolshek@kolshek-local": true}
+      }' > "$settings_file"
+      info "Created $settings_file with plugin settings"
+    fi
+  else
+    warn "jq not found — add these settings to $settings_file manually:"
+    echo '  "extraKnownMarketplaces": {"kolshek-local": {"source": {"source": "directory", "path": "'"$marketplace_dir"'"}}}'
+    echo '  "enabledPlugins": {"kolshek@kolshek-local": true}'
+  fi
+  echo "  Restart Claude Code to activate the plugin."
 }
 
 # --- OpenCode ---

--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -8,6 +8,17 @@
 
 $ErrorActionPreference = 'Stop'
 
+# Detect non-interactive execution (e.g., inside an AI coding agent)
+try {
+    if ([Console]::IsInputRedirected) {
+        Write-Warn "Running non-interactively (e.g., inside an AI agent)."
+        Write-Warn "Install will work, but open a new terminal afterward to use kolshek."
+        Write-Host ""
+    }
+} catch {
+    # [Console]::IsInputRedirected may not be available in all hosts
+}
+
 $Repo = "DaveDushi/kolshek"
 $DefaultInstallDir = "$env:LOCALAPPDATA\kolshek"
 $InstallDir = if ($env:KOLSHEK_INSTALL_DIR) { $env:KOLSHEK_INSTALL_DIR } else { $DefaultInstallDir }
@@ -157,14 +168,18 @@ Write-Host "  KolShek " -NoNewline
 Write-Host "v$DisplayVersion" -ForegroundColor Green -NoNewline
 Write-Host " installed successfully!"
 Write-Host ""
-Write-Host "  Get started:"
-Write-Host "    kolshek init" -ForegroundColor Cyan -NoNewline
-Write-Host "     Set up your first bank or credit card"
-Write-Host ""
 
-# Check if available in current session
+# Show appropriate next steps depending on whether kolshek is on PATH
 $TestCmd = Get-Command kolshek -ErrorAction SilentlyContinue
-if (-not $TestCmd) {
-    Write-Host "  Restart your terminal for PATH changes to take effect." -ForegroundColor Yellow
-    Write-Host ""
+if ($TestCmd) {
+    Write-Host "  Get started:"
+    Write-Host "    kolshek init" -ForegroundColor Cyan -NoNewline
+    Write-Host "     Set up your first bank or credit card"
+} else {
+    Write-Host "  Next steps:" -ForegroundColor Yellow
+    Write-Host "    1. Open a new PowerShell terminal"
+    Write-Host "    2. Run: " -NoNewline
+    Write-Host "kolshek init" -ForegroundColor Cyan -NoNewline
+    Write-Host "  to set up your first bank or credit card"
 }
+Write-Host ""

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -8,6 +8,13 @@
 #   KOLSHEK_VERSION      Install a specific version (default: latest)
 set -eu
 
+# Detect non-interactive execution (e.g., inside an AI coding agent)
+if [ ! -t 0 ]; then
+  printf '\033[33mwarn\033[0m  Running non-interactively (e.g., inside an AI agent).\n'
+  printf '\033[33mwarn\033[0m  Install will work, but open a new terminal afterward to use kolshek.\n'
+  printf '\n'
+fi
+
 REPO="DaveDushi/kolshek"
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 INSTALL_DIR="${KOLSHEK_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
@@ -258,13 +265,14 @@ DISPLAY_VERSION="$(echo "$TAG" | sed 's/^v//')"
 printf "\n"
 printf "  ${BOLD}KolShek ${GREEN}v%s${RESET} installed successfully!\n" "$DISPLAY_VERSION"
 printf "\n"
-printf "  Get started:\n"
-printf "    ${CYAN}kolshek init${RESET}     Set up your first bank or credit card\n"
-printf "\n"
 
-# Check if the binary is available in current PATH
-if ! command -v kolshek >/dev/null 2>&1; then
-  printf "  ${YELLOW}Restart your terminal${RESET} for PATH changes to take effect, or run:\n"
-  printf "    export PATH=\"%s:\$PATH\"\n" "$INSTALL_DIR"
-  printf "\n"
+# Show appropriate next steps depending on whether kolshek is on PATH
+if command -v kolshek >/dev/null 2>&1; then
+  printf "  Get started:\n"
+  printf "    ${CYAN}kolshek init${RESET}     Set up your first bank or credit card\n"
+else
+  printf "  ${YELLOW}Next steps:${RESET}\n"
+  printf "    1. Open a new terminal (or run: ${CYAN}export PATH=\"%s:\$PATH\"${RESET})\n" "$INSTALL_DIR"
+  printf "    2. Run: ${CYAN}kolshek init${RESET}  to set up your first bank or credit card\n"
 fi
+printf "\n"

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -50,22 +50,38 @@ export function registerInitCommand(program: Command): void {
   program
     .command("init")
     .description("First-run setup wizard — configure your first provider")
-    .action(async () => {
+    .option("--setup-only", "Initialize database and directories only (no interactive wizard)")
+    .action(async (opts: { setupOnly?: boolean }) => {
+      // --setup-only: headless DB/dir init for use by AI agents
+      if (opts.setupOnly) {
+        await ensureDirectories();
+        initDatabase(getDbPath());
+        if (isJsonMode()) {
+          printJson(jsonSuccess({ status: "initialized" }));
+        } else {
+          success("Database and directories initialized.");
+          info("  Add providers: run 'kolshek init' in your terminal.");
+        }
+        return;
+      }
+
       if (!isInteractive()) {
         if (isJsonMode()) {
           printJson(
-            jsonError("NON_INTERACTIVE", "init requires interactive mode", {
+            jsonError("NON_INTERACTIVE", "init requires an interactive terminal for credential entry", {
               suggestions: [
-                "Run without --non-interactive",
-                "Use 'kolshek providers add' with env var credentials instead",
+                "Run 'kolshek init' in your own terminal (not inside an AI agent)",
+                "Use 'kolshek init --setup-only' to initialize the database without the wizard",
+                "Use 'kolshek providers add' in your terminal to add providers individually",
               ],
             }),
           );
         } else {
-          printError("NON_INTERACTIVE", "init requires interactive mode", {
+          printError("NON_INTERACTIVE", "init requires an interactive terminal for credential entry", {
             suggestions: [
-              "Run without --non-interactive",
-              "Use 'kolshek providers add' with env var credentials instead",
+              "Run 'kolshek init' in your own terminal (not inside an AI agent)",
+              "Use 'kolshek init --setup-only' to initialize the database without the wizard",
+              "Use 'kolshek providers add' in your terminal to add providers individually",
             ],
           });
         }
@@ -346,11 +362,20 @@ export function registerInitCommand(program: Command): void {
       });
 
       if (aiTool !== "skip") {
-        const { installPlugin } = await import("./plugin.js");
+        const { installPlugin, registerClaudeCodePlugin } = await import("./plugin.js");
         const result = installPlugin(aiTool);
         if (result.success) {
           success(`Installed ${result.count} files for ${result.description}`);
           info(`  Location: ${result.dir}`);
+          if (aiTool === "claude-code") {
+            const reg = registerClaudeCodePlugin(result.dir);
+            if (reg.ok) {
+              success(reg.message);
+              info("  Restart Claude Code to activate the plugin.");
+            } else {
+              warn(reg.message);
+            }
+          }
         }
       }
 

--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Command } from "commander";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
 import {
@@ -70,6 +70,78 @@ function writeFiles(
   return count;
 }
 
+const MARKETPLACE_NAME = "kolshek-local";
+
+// Write a marketplace.json wrapper so Claude Code discovers the plugin
+// via the extraKnownMarketplaces + enabledPlugins settings mechanism.
+function writeMarketplaceManifest(marketplaceDir: string): void {
+  const manifest = {
+    name: MARKETPLACE_NAME,
+    owner: { name: "KolShek" },
+    plugins: [
+      {
+        name: "kolshek",
+        source: "./kolshek",
+        description: "KolShek — Israeli finance CLI plugin for Claude Code",
+      },
+    ],
+  };
+  const manifestPath = join(marketplaceDir, ".claude-plugin", "marketplace.json");
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+}
+
+// Register the plugin in ~/.claude/settings.json so it auto-loads.
+// Merges extraKnownMarketplaces + enabledPlugins without clobbering
+// other settings. Returns a status message for display.
+export function registerClaudeCodePlugin(
+  marketplaceDir: string,
+): { ok: boolean; message: string } {
+  const claudeDir = join(homedir(), ".claude");
+  const settingsPath = join(claudeDir, "settings.json");
+
+  if (!existsSync(claudeDir)) {
+    mkdirSync(claudeDir, { recursive: true });
+  }
+
+  let settings: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    } catch {
+      return {
+        ok: false,
+        message: `Could not parse ${settingsPath} — add plugin settings manually.`,
+      };
+    }
+  }
+
+  // Merge extraKnownMarketplaces
+  const markets = (settings.extraKnownMarketplaces ?? {}) as Record<string, unknown>;
+  markets[MARKETPLACE_NAME] = {
+    source: {
+      source: "directory",
+      path: marketplaceDir.replace(/\\/g, "/"),
+    },
+  };
+  settings.extraKnownMarketplaces = markets;
+
+  // Merge enabledPlugins
+  const enabled = (settings.enabledPlugins ?? {}) as Record<string, boolean>;
+  enabled[`kolshek@${MARKETPLACE_NAME}`] = true;
+  settings.enabledPlugins = enabled;
+
+  try {
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    return { ok: true, message: "Registered KolShek plugin in Claude Code settings." };
+  } catch (err) {
+    return {
+      ok: false,
+      message: `Could not write ${settingsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
 export function installPlugin(
   tool: string,
   pluginFiles?: PluginBundle,
@@ -86,7 +158,16 @@ export function installPlugin(
   }
 
   const target = getInstallTarget(tool as Tool);
-  const count = writeFiles(files, target.dir);
+
+  // For claude-code, nest plugin files inside a marketplace wrapper
+  const writeDir = tool === "claude-code"
+    ? join(target.dir, "kolshek")
+    : target.dir;
+  const count = writeFiles(files, writeDir);
+
+  if (tool === "claude-code") {
+    writeMarketplaceManifest(target.dir);
+  }
 
   return { success: true, count, dir: target.dir, description: target.description };
 }
@@ -148,9 +229,13 @@ export function registerPluginCommand(program: Command): void {
         info(`  Location: ${result.dir}`);
 
         if (tool === "claude-code") {
-          info(
-            `  Add to settings: "pluginDirs": ["${result.dir}"]`,
-          );
+          const reg = registerClaudeCodePlugin(result.dir);
+          if (reg.ok) {
+            success(`  ${reg.message}`);
+            info("  Restart Claude Code to activate the plugin.");
+          } else {
+            warn(`  ${reg.message}`);
+          }
         } else if (tool === "opencode") {
           warn("  Project-scoped — run from your project root.");
         }


### PR DESCRIPTION
## Summary
- **pluginDirs is dead** — not in the Claude Code settings schema, plugin never loads. Replaced with the official marketplace mechanism (`extraKnownMarketplaces` + `enabledPlugins`)
- Plugin install now creates a local marketplace wrapper (`marketplace.json`) and auto-writes settings to `~/.claude/settings.json`
- Detect non-interactive shells (AI agents) in both installers and warn early
- Add `--setup-only` flag to `kolshek init` for headless DB/dir initialization
- Restructure installer success message to show "open a new terminal" before "kolshek init" when PATH isn't ready

## Test plan
- [ ] `bun run dev -- plugin install claude-code` — verify marketplace structure at `~/.claude/plugins/kolshek/` and `settings.json` updated
- [ ] `bun run dev -- plugin install claude-code` again — idempotent, no duplicates
- [ ] `bun run dev -- init --setup-only` — creates DB without prompting
- [ ] `bun run dev -- init --setup-only --json` — returns `{ success: true, data: { status: "initialized" } }`
- [ ] `echo | bun run dev -- init` — shows improved non-interactive error with `--setup-only` suggestion
- [ ] Review `install.ps1` and `install.sh` output messages manually
- [ ] `bun run typecheck` — clean
- [ ] `bun test` — 243 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)