### PR TITLE
fix(web): restore and extend dashboard origin/session hardening

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -26,3 +26,10 @@ KOLSHEK_OTP=
 # Run Chrome with --no-sandbox (needed in some containers)
 # @type=boolean
 KOLSHEK_NO_SANDBOX=
+
+# Dev mode — set to 1 only when running the Vite dev server (bun run dev:web).
+# Adds http://localhost:5173 to the dashboard's trusted origins and writes the
+# session token to .dev-session for the Vite proxy. Do NOT set this in normal
+# use: :5173 is same-site with the dashboard, so trusting it lets any local
+# process that binds that port drive the dashboard without the session token.
+KOLSHEK_DEV=

--- a/src/core/page-schema.ts
+++ b/src/core/page-schema.ts
@@ -166,6 +166,7 @@ const gridSchema: z.ZodType<unknown> = z.lazy(() =>
       md: z.number().int().min(1).max(12).optional(),
       lg: z.number().int().min(1).max(12).optional(),
     }).optional(),
+    gap: z.number().int().min(0).max(16).optional(),
     children: z.array(widgetSchema).min(1).max(50),
   }),
 );

--- a/src/web/app/components/widgets/widget-grid.tsx
+++ b/src/web/app/components/widgets/widget-grid.tsx
@@ -8,12 +8,24 @@ function gapToRem(gap: number): string {
   return `${gap * 0.25}rem`;
 }
 
+// Coerce to a bounded integer.
+function toBoundedInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  const i = Math.trunc(n);
+  if (i < min || i > max) return fallback;
+  return i;
+}
+
 export default function WidgetGrid({ config, renderWidget }: LayoutWidgetProps) {
   const children = (config.children as Record<string, unknown>[]) || [];
-  const colsSm = (config.colsSm as number) || 1;
-  const colsMd = (config.colsMd as number) || 2;
-  const colsLg = (config.colsLg as number) || 3;
-  const gap = (config.gap as number) || 4;
+  // Must match gridSchema in core/page-schema.ts, validation strips unknown
+  // keys, so a name mismatch silently disables the feature.
+  const columns = (config.columns ?? {}) as Record<string, unknown>;
+  const colsSm = toBoundedInt(columns.sm, 1, 1, 12);
+  const colsMd = toBoundedInt(columns.md, 2, 1, 12);
+  const colsLg = toBoundedInt(columns.lg, 3, 1, 12);
+  const gap = toBoundedInt(config.gap, 4, 0, 16);
 
   // Unique id for scoped responsive styles
   const rawId = useId();

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,7 +3,8 @@
 // Authentication: single-use token in URL → HttpOnly session cookie.
 
 import { resolve } from "node:path";
-import { randomBytes } from "node:crypto";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { WEB_FILES } from "./web-files.js";
 import {
   listProviders,
@@ -147,31 +148,47 @@ function serveEmbedded(key: string, cacheControl: string, extraHeaders?: Record<
 
 // --- JSON API helpers ---
 
-// Allowed origins for CORS (Vite dev on :5173, server on :3000)
-function getAllowedOrigins(port: number): string[] {
-  return [
-    `http://localhost:${port}`,
-    `http://127.0.0.1:${port}`,
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-  ];
+// Dev mode - enablss the Vite proxy integration.
+export function isDevMode(): boolean {
+  return process.env.KOLSHEK_DEV === "1";
 }
 
-function corsHeaders(origin: string | null, allowedOrigins: string[]): Record<string, string> {
-  // Only reflect the origin if it's in our allowlist
-  const allowed = origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+// Allowed origins for CORS
+export function getAllowedOrigins(port: number): string[] {
+  const origins = [
+    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
+  ];
+  if (isDevMode()) {
+    origins.push("http://localhost:5173", "http://127.0.0.1:5173");
+  }
+  return origins;
+}
+
+export function corsHeaders(origin: string | null, allowedOrigins: string[]): Record<string, string> {
   const headers: Record<string, string> = {
-    "Access-Control-Allow-Origin": allowed,
     "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     Vary: "Origin",
   };
-  // Allow credentials (cookies) for cross-origin Vite dev server requests.
-  // Only set when the origin is an actual allowed origin (never for the fallback).
+  // Unknown origins get no ACAO at all - same-origin requests don't need it.
   if (origin && allowedOrigins.includes(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin;
     headers["Access-Control-Allow-Credentials"] = "true";
   }
   return headers;
+}
+
+// Defense against DNS rebinding - Bun already binds 127.0.0.1.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+export function isLoopbackHost(hostHeader: string | null): boolean {
+  if (!hostHeader) return false;
+  // "localhost:45091" → "localhost", "[::1]:45091" → "[::1]"
+  const host = hostHeader.startsWith("[")
+    ? hostHeader.slice(0, hostHeader.indexOf("]") + 1)
+    : hostHeader.split(":")[0];
+  return LOOPBACK_HOSTS.has(host.toLowerCase());
 }
 
 // Security headers applied to all responses
@@ -185,12 +202,26 @@ const SECURITY_HEADERS: Record<string, string> = {
 // MAX_PAGINATION_LIMIT prevents dumping entire DB via ?limit=999999999
 const MAX_PAGINATION_LIMIT = 500;
 
-// Validate that a user-supplied regex isn't pathologically complex (ReDoS)
-function isSafeRegex(pattern: string): boolean {
+// Constant-time string comparison to prevent timing attacks on tokens.
+export function safeEqual(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+// Best effort ReDoS heuristic
+// Patterns come from the authenticated local user, so worst case is their own CPU.
+export function isSafeRegex(pattern: string): boolean {
   // Reject patterns longer than 200 chars
   if (pattern.length > 200) return false;
   // Reject nested quantifiers like (a+)+ or (a*)*
   if (/(\+|\*|\{)\)?(\+|\*|\{)/.test(pattern)) return false;
+  // Quantified alternation: (a|a)+ , (?:ab|ab)*
+  if (/\([^)]*\|[^)]*\)\s*(\*|\+|\{\d+(,\d*)?\})/.test(pattern)) return false;
+  // Quantified group with a quantified body: (?:a{10}){10}
+  if (/\([^)]*\{\d+(,\d*)?\}[^)]*\)\s*(\*|\+|\{\d+(,\d*)?\})/.test(pattern)) return false;
   // Reject excessive alternation groups
   if ((pattern.match(/\|/g) || []).length > 20) return false;
   // Try constructing — reject invalid
@@ -203,10 +234,10 @@ function isSafeRegex(pattern: string): boolean {
 }
 
 // Sanitize error messages — strip file paths and internal details
-function sanitizeError(msg: string): string {
-  // Remove Windows/Unix file paths
-  return msg.replace(/[A-Z]:\\[^\s:]+/gi, "[path]")
-    .replace(/\/[^\s:]*\/[^\s:]*/g, "[path]")
+export function sanitizeError(msg: string): string {
+  return msg
+    .replace(/[A-Za-z]:\\[^\s:*?"<>|]+/g, "[path]")
+    .replace(/(?<![\w/])(?:\/[\w.@-]+){2,}\/?/g, "[path]")
     .replace(/at\s+.+\(.+\)/g, "")
     .trim();
 }
@@ -270,17 +301,27 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
   let allowedOrigins: string[] = [];
 
   // Generate a one-time session token — only the CLI user sees this in the terminal.
-  // The token is exchanged for an HttpOnly cookie on first visit.
+  // Single-use: consumed on first visit, so replay from history is rejected.
   const sessionToken = randomBytes(32).toString("hex");
+  let urlTokenConsumed = false;
   const cookieName = "kolshek_session";
 
   // Write session token to .dev-session so the Vite dev proxy can inject it.
-  // This file is gitignored and only used for local development.
-  try {
-    const devSessionPath = resolve(import.meta.dir, "../../.dev-session");
-    Bun.write(devSessionPath, `${cookieName}=${sessionToken}`).catch(() => {});
-  } catch {
-    // Non-fatal — only needed for Vite dev mode
+  // A live credential in plaintext — dev-only, owner-only, removed on exit.
+  if (isDevMode()) {
+    try {
+      const devSessionPath = resolve(import.meta.dir, "../../.dev-session");
+      // Not Bun.write — it silently ignores { mode } - oven-sh/bun#32885,
+      writeFileSync(devSessionPath, `${cookieName}=${sessionToken}`, { mode: 0o600 });
+      const cleanup = () => {
+        try { unlinkSync(devSessionPath); } catch { /* already gone */ }
+      };
+      process.once("exit", cleanup);
+      process.once("SIGINT", () => { cleanup(); process.exit(130); });
+      process.once("SIGTERM", () => { cleanup(); process.exit(143); });
+    } catch {
+      // Non-fatal — only needed for Vite dev mode
+    }
   }
 
   // Parse the session cookie from a Cookie header
@@ -293,18 +334,17 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
     return null;
   }
 
-  // Check if a request is authenticated (has valid cookie OR valid token query param)
-  function isAuthenticated(req: Request, url: URL): boolean {
-    // Check cookie first (most requests)
-    if (getSessionCookie(req) === sessionToken) return true;
-    // Check query param (initial browser open)
-    if (url.searchParams.get("token") === sessionToken) return true;
-    return false;
+  // Check if a request is authenticated. Cookie only - the URL token is not
+  // accepted, it is exchanged for a cookie once and
+  // then invalidated (see the ?token= branch below).
+  function isAuthenticated(req: Request): boolean {
+    const cookie = getSessionCookie(req);
+    return cookie !== null && safeEqual(cookie, sessionToken);
   }
 
-  // Build a Set-Cookie header that persists the session
+  // Build a Set-Cookie header that persists the session.
   function sessionCookieHeader(): string {
-    return `${cookieName}=${sessionToken}; Path=/; HttpOnly; SameSite=Strict; Max-Age=86400`;
+    return `${cookieName}=${sessionToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Max-Age=86400`;
   }
 
   const server = Bun.serve({
@@ -324,6 +364,11 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
       const json = makeJsonFn(cors);
       const jsonError = makeJsonErrorFn(cors);
 
+      // Reject non-loopback Host headers before anything else (DNS rebinding).
+      if (!isLoopbackHost(req.headers.get("host"))) {
+        return new Response("Forbidden: invalid Host header", { status: 403 });
+      }
+
       // CORS preflight (no auth needed)
       if (method === "OPTIONS") {
         return new Response(null, { status: 204, headers: cors });
@@ -337,7 +382,7 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
       if (method === "POST" && path === "/api/v2/auth/token") {
         const body = await parseJsonBody(req);
         const token = typeof body.token === "string" ? body.token : "";
-        if (token !== sessionToken) {
+        if (!safeEqual(token, sessionToken)) {
           return jsonError("UNAUTHORIZED", "Invalid token.", 401);
         }
         return new Response(JSON.stringify({ success: true, data: null }), {
@@ -352,13 +397,18 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
       }
 
       // If the request has ?token= in the URL, validate it and set a cookie.
-      // This is the initial browser open from the CLI.
+      // This is the initial browser open from the CLI. 
       if (url.searchParams.has("token")) {
-        if (url.searchParams.get("token") !== sessionToken) {
-          return new Response("Unauthorized: invalid token", { status: 401 });
+        const urlToken = url.searchParams.get("token") ?? "";
+        if (urlTokenConsumed || !safeEqual(urlToken, sessionToken)) {
+          return new Response(
+            "Unauthorized: token already used or invalid. Relaunch the dashboard.",
+            { status: 401 },
+          );
         }
-        // Valid token — redirect to the same URL without the token param
-        // and set the session cookie so future requests are authenticated.
+        urlTokenConsumed = true;
+        // Redirect to the same URL without the token param and set the session
+        // cookie so future requests are authenticated.
         url.searchParams.delete("token");
         const cleanUrl = url.pathname + (url.search || "");
         return new Response(null, {
@@ -366,12 +416,13 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
           headers: {
             Location: cleanUrl || "/",
             "Set-Cookie": sessionCookieHeader(),
+            "Cache-Control": "no-store",
           },
         });
       }
 
       // All other requests must have the session cookie
-      if (!isAuthenticated(req, url)) {
+      if (!isAuthenticated(req)) {
         if (path.startsWith("/api/")) {
           return jsonError("UNAUTHORIZED", "Session expired. Relaunch the dashboard.", 401);
         }
@@ -381,16 +432,11 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
         );
       }
 
-      // CSRF protection: block cross-origin mutations using exact origin match.
-      // Reject if origin is missing (non-browser clients must not mutate via API)
-      // or if origin is not in the allowlist.
-      if (method !== "GET" && method !== "HEAD") {
-        if (!reqOrigin || !allowedOrigins.includes(reqOrigin)) {
-          return new Response("Forbidden: cross-origin request", {
-            status: 403,
-            headers: cors,
-          });
-        }
+      // CSRF: a present Origin must be allowlisted. Reads may omit it —
+      // same-origin GETs do — but mutations without one are non-browser clients.
+      const isMutation = method !== "GET" && method !== "HEAD";
+      if (reqOrigin ? !allowedOrigins.includes(reqOrigin) : isMutation) {
+        return new Response("Forbidden: cross-origin request", { status: 403, headers: cors });
       }
 
       try {
@@ -1211,7 +1257,8 @@ export function startDashboard(port: number): { server: ReturnType<typeof Bun.se
                 if (!result.success) {
                   return jsonError("PAGE_VALIDATION_FAILED", result.error, 400);
                 }
-                updates.definition = body.layout;
+                // Zod parse strip fields, we want the parsed version
+                updates.definition = result.data.layout;
               }
               const page = updateCustomPage(pageUpdateMatch[1], updates);
               if (!page) return jsonError("PAGE_NOT_FOUND", "Page not found", 404);

--- a/tests/integration/dashboard-auth.test.ts
+++ b/tests/integration/dashboard-auth.test.ts
@@ -1,0 +1,107 @@
+// End-to-end checks on dashboard authentication and origin handling. This
+// hardening shipped in v0.3.8 and was silently dropped by a merge; nothing
+// covered it, so nobody noticed. Skipped under vitest/node (needs Bun.serve).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { startDashboard } from "../../src/web/server.js";
+
+const hasBunServe = typeof globalThis.Bun !== "undefined" && typeof globalThis.Bun?.serve === "function";
+
+type Started = ReturnType<typeof startDashboard>;
+let running: Started | null = null;
+
+function start(): { base: string; token: string } {
+  running = startDashboard(0);
+  return { base: `http://127.0.0.1:${running.server.port}`, token: running.token };
+}
+
+afterEach(() => {
+  running?.server.stop(true);
+  running = null;
+});
+
+describe.skipIf(!hasBunServe)("dashboard authentication", () => {
+  it("rejects unauthenticated API requests", async () => {
+    const { base } = start();
+    const res = await fetch(`${base}/api/v2/providers`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an invalid URL token", async () => {
+    const { base } = start();
+    const res = await fetch(`${base}/?token=wrong`, { redirect: "manual" });
+    expect(res.status).toBe(401);
+  });
+
+  it("exchanges a valid URL token for a session cookie", async () => {
+    const { base, token } = start();
+    const res = await fetch(`${base}/?token=${token}`, { redirect: "manual" });
+    expect(res.status).toBe(302);
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("kolshek_session=");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Strict");
+    expect(cookie).toContain("Secure");
+  });
+
+  it("consumes the URL token — a second use is rejected", async () => {
+    const { base, token } = start();
+    const first = await fetch(`${base}/?token=${token}`, { redirect: "manual" });
+    expect(first.status).toBe(302);
+    const replay = await fetch(`${base}/?token=${token}`, { redirect: "manual" });
+    expect(replay.status).toBe(401);
+  });
+
+  it("does not accept the URL token as a standing credential on the API", async () => {
+    const { base, token } = start();
+    const res = await fetch(`${base}/api/v2/providers?token=${token}`);
+    expect(res.status).not.toBe(200);
+  });
+});
+
+describe.skipIf(!hasBunServe)("dashboard origin and host enforcement", () => {
+  it("blocks reads and mutations from the Vite dev origin outside dev mode", async () => {
+    const { base, token } = start();
+    const cookie = `kolshek_session=${token}`;
+
+    const read = await fetch(`${base}/api/v2/providers`, {
+      headers: { Cookie: cookie, Origin: "http://localhost:5173" },
+    });
+    expect(read.status).toBe(403);
+
+    const write = await fetch(`${base}/api/v2/providers`, {
+      method: "POST",
+      headers: { Cookie: cookie, Origin: "http://localhost:5173", "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(write.status).toBe(403);
+  });
+
+  it("blocks mutations carrying no Origin header", async () => {
+    const { base, token } = start();
+    const res = await fetch(`${base}/api/v2/providers`, {
+      method: "POST",
+      headers: { Cookie: `kolshek_session=${token}`, "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a non-loopback Host header (DNS rebinding)", async () => {
+    const { base, token } = start();
+    const res = await fetch(`${base}/api/v2/providers`, {
+      headers: { Cookie: `kolshek_session=${token}`, Host: "evil.example" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("never reflects an unknown origin in Access-Control-Allow-Origin", async () => {
+    const { base } = start();
+    const res = await fetch(`${base}/api/v2/providers`, {
+      method: "OPTIONS",
+      headers: { Origin: "http://evil.example" },
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+});

--- a/tests/unit/web-security.test.ts
+++ b/tests/unit/web-security.test.ts
@@ -1,0 +1,186 @@
+// Dashboard access-control helpers: origin allowlisting, CORS header emission,
+// Host validation, and the two sanitising helpers.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getAllowedOrigins,
+  corsHeaders,
+  isLoopbackHost,
+  isSafeRegex,
+  sanitizeError,
+  isDevMode,
+  safeEqual,
+} from "../../src/web/server.js";
+
+const PORT = 45091;
+
+describe("isDevMode", () => {
+  const original = process.env.KOLSHEK_DEV;
+  afterEach(() => {
+    if (original === undefined) delete process.env.KOLSHEK_DEV;
+    else process.env.KOLSHEK_DEV = original;
+  });
+
+  it("is off by default", () => {
+    delete process.env.KOLSHEK_DEV;
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("requires the exact opt-in value — truthy strings are not enough", () => {
+    for (const v of ["", "0", "true", "yes", "dev"]) {
+      process.env.KOLSHEK_DEV = v;
+      expect(isDevMode()).toBe(false);
+    }
+    process.env.KOLSHEK_DEV = "1";
+    expect(isDevMode()).toBe(true);
+  });
+});
+
+describe("getAllowedOrigins", () => {
+  const original = process.env.KOLSHEK_DEV;
+  beforeEach(() => { delete process.env.KOLSHEK_DEV; });
+  afterEach(() => {
+    if (original === undefined) delete process.env.KOLSHEK_DEV;
+    else process.env.KOLSHEK_DEV = original;
+  });
+
+  it("trusts only the dashboard's own origin outside dev mode", () => {
+    expect(getAllowedOrigins(PORT)).toEqual([
+      `http://localhost:${PORT}`,
+      `http://127.0.0.1:${PORT}`,
+    ]);
+  });
+
+  it("does not trust the Vite dev port outside dev mode", () => {
+    const origins = getAllowedOrigins(PORT);
+    expect(origins).not.toContain("http://localhost:5173");
+    expect(origins).not.toContain("http://127.0.0.1:5173");
+  });
+
+  it("trusts the Vite dev port only when explicitly opted in", () => {
+    process.env.KOLSHEK_DEV = "1";
+    const origins = getAllowedOrigins(PORT);
+    expect(origins).toContain("http://localhost:5173");
+    expect(origins).toContain("http://127.0.0.1:5173");
+  });
+});
+
+describe("corsHeaders", () => {
+  const allowed = [`http://localhost:${PORT}`, `http://127.0.0.1:${PORT}`];
+
+  it("reflects and credentials an allowlisted origin", () => {
+    const h = corsHeaders(`http://localhost:${PORT}`, allowed);
+    expect(h["Access-Control-Allow-Origin"]).toBe(`http://localhost:${PORT}`);
+    expect(h["Access-Control-Allow-Credentials"]).toBe("true");
+  });
+
+  it("emits no ACAO or credentials for an unknown origin", () => {
+    const h = corsHeaders("http://evil.example", allowed);
+    expect(h["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(h["Access-Control-Allow-Credentials"]).toBeUndefined();
+  });
+
+  it("emits no ACAO when the request has no Origin header", () => {
+    const h = corsHeaders(null, allowed);
+    expect(h["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(h["Access-Control-Allow-Credentials"]).toBeUndefined();
+  });
+
+  it("never credentials an origin it did not reflect", () => {
+    for (const origin of [null, "http://evil.example", "http://localhost:5173"]) {
+      const h = corsHeaders(origin, allowed);
+      if (h["Access-Control-Allow-Credentials"] === "true") {
+        expect(h["Access-Control-Allow-Origin"]).toBe(origin);
+      }
+    }
+  });
+
+  it("always varies on Origin so caches don't cross origins", () => {
+    expect(corsHeaders(null, allowed).Vary).toBe("Origin");
+  });
+});
+
+describe("safeEqual", () => {
+  it("matches identical strings", () => {
+    expect(safeEqual("abc123", "abc123")).toBe(true);
+  });
+
+  it("rejects differing strings, including length mismatches", () => {
+    expect(safeEqual("abc123", "abc124")).toBe(false);
+    expect(safeEqual("abc", "abc123")).toBe(false);
+    expect(safeEqual("", "abc")).toBe(false);
+  });
+
+  it("does not throw on non-string input", () => {
+    expect(safeEqual(undefined as unknown as string, "abc")).toBe(false);
+    expect(safeEqual(null as unknown as string, "abc")).toBe(false);
+  });
+
+  it("compares empty strings as equal", () => {
+    expect(safeEqual("", "")).toBe(true);
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it("accepts loopback names with and without a port", () => {
+    for (const h of ["localhost", "localhost:45091", "127.0.0.1", "127.0.0.1:45091", "[::1]", "[::1]:45091"]) {
+      expect(isLoopbackHost(h)).toBe(true);
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(isLoopbackHost("LocalHost:45091")).toBe(true);
+  });
+
+  it("rejects rebinding-style and absent hosts", () => {
+    for (const h of ["evil.example", "evil.example:45091", "localhost.evil.example", "10.0.0.5", "", null]) {
+      expect(isLoopbackHost(h)).toBe(false);
+    }
+  });
+});
+
+describe("isSafeRegex", () => {
+  it("accepts ordinary merchant patterns", () => {
+    for (const p of ["^SUPER", "shufersal|rami levy", "\\d{4}$", "café.*"]) {
+      expect(isSafeRegex(p)).toBe(true);
+    }
+  });
+
+  it("rejects nested quantifiers", () => {
+    expect(isSafeRegex("(a+)+")).toBe(false);
+    expect(isSafeRegex("(a*)*")).toBe(false);
+  });
+
+  it("rejects quantified overlapping alternation", () => {
+    expect(isSafeRegex("(a|a)+")).toBe(false);
+    expect(isSafeRegex("(?:ab|ab)*")).toBe(false);
+  });
+
+  it("rejects a quantified group with a quantified body", () => {
+    expect(isSafeRegex("(?:a{10}){10}")).toBe(false);
+  });
+
+  it("rejects over-long patterns, excessive alternation, and invalid syntax", () => {
+    expect(isSafeRegex("a".repeat(201))).toBe(false);
+    expect(isSafeRegex(Array(22).fill("a").join("|"))).toBe(false);
+    expect(isSafeRegex("(unclosed")).toBe(false);
+  });
+});
+
+describe("sanitizeError", () => {
+  it("redacts absolute POSIX and Windows paths", () => {
+    expect(sanitizeError("failed to open /Users/alice/.local/share/kolshek/kolshek.db"))
+      .not.toContain("alice");
+    expect(sanitizeError("failed to open C:\\Users\\alice\\kolshek.db"))
+      .not.toContain("alice");
+  });
+
+  it("strips stack frames", () => {
+    expect(sanitizeError("boom at handler (/app/server.ts:12:3)")).not.toContain("server.ts");
+  });
+
+  it("leaves non-path message text intact", () => {
+    expect(sanitizeError("date must be YYYY/MM/DD")).toBe("date must be YYYY/MM/DD");
+    expect(sanitizeError("expected income/expense")).toBe("expected income/expense");
+  });
+});


### PR DESCRIPTION
Two groups of changes, both in the dashboard request path. Found while doing a security review of the project.

## 1. Four v0.3.8 hardening measures were lost in a merge

The CHANGELOG under **v0.3.8 → Security** claims these. None of them are in `master`:

| Claimed in v0.3.8 | In v0.4.8 |
|---|---|
| Constant-time token comparison | absent — plain `===` |
| Single-use URL token | absent — replayable indefinitely |
| `KOLSHEK_DEV` dev-mode gating | absent |
| `Secure` cookie flag | absent |

Traced to merge `712ebf7`: first parent `488a420` carried the hardening, second parent `a31b007` (the `dashboard-ai-chat-agent` branch, forked before v0.3.8) did not, and the resolution took the version without it. Nothing tested any of it, so nothing caught it.

This PR restores all four.

## 2. Findings from the review

- **Gate the `:5173` Vite origins behind `KOLSHEK_DEV`.** Cookies are not port-scoped (RFC 6265 §8.5) and SameSite compares scheme + registrable domain ignoring port, so `:5173` is *same-site* with the dashboard. Trusting it unconditionally let any local process that binds that port issue credentialed, readable, state-changing requests — with no session token. This is the same gate as the lost v0.3.8 one.
- **`.dev-session` is dev-only now**, written `0600` instead of `Bun.write`'s default `0644`, and unlinked on exit. It holds a live session token.
- **Persist the validated page layout** (`result.data.layout`) instead of the raw request body on `PUT /api/v2/pages/:id`. Zod returns a stripped copy rather than mutating its input, and `z.object()` drops unknown keys silently instead of rejecting, so the raw body carried arbitrary unvalidated fields past validation. Those fields reach an inline `<style>` sink in `WidgetGrid`.
- **Align `WidgetGrid` with `gridSchema`** (`columns.sm/md/lg`, not `colsSm/colsMd/colsLg`) and clamp interpolated values to bounded integers at the sink. The naming mismatch had silently disabled responsive columns.
- **Omit `Access-Control-Allow-Origin`** for unknown origins rather than falling back to `allowedOrigins[0]`.
- **Reject non-loopback `Host` headers** (DNS rebinding), before auth or routing.
- **Reject reads carrying a present-but-unrecognised `Origin`.** CORS already stops the caller reading the response; no reason to run the handler for it.
- **Narrow `sanitizeError` to absolute paths.** The previous pattern matched any `a/b` substring, mangling messages like `date must be YYYY/MM/DD`.
- **Extend `isSafeRegex`** to quantified alternations `(a|a)+` and quantified quantified-bodies `(?:a{10}){10}`.

## Verification

Beyond the 34 new tests, the behaviour was checked against a running server:

```
                                    default    KOLSHEK_DEV=1
GET  /api  Origin :5173             403        200
POST /api  Origin :5173             403        reaches handler
POST /api  Origin own-port          reaches handler
GET  /api  Host: evil.example       403        403
.dev-session                        absent     0600, removed on exit
```

The real dev workflow was also round-tripped (`KOLSHEK_DEV=1 … dashboard` + `bun run dev:web`, requests through the actual Vite proxy) to confirm the gate doesn't break it: `GET` through the proxy returns 200.

`bun run typecheck` clean, `bun test` 302 pass / 0 fail.

## Two things worth your call

1. **`Secure` on the session cookie.** Restored from v0.3.8. Verified working in Chrome on both `localhost` and `127.0.0.1`, but **unverified on Safari**, which is historically the holdout for `Secure` cookies over plain `http://localhost` — and `open` uses the default browser. If Safari rejects it, every request after the redirect 401s and the dashboard is unusable there. Its security value is near zero given the loopback bind plus the new `Host` check, so it's easy to drop if you'd rather not risk it.

2. **Bundling.** The v0.3.8 restoration and the review findings are in one commit because they touch the same function — this fix *is* one of the lost measures. Happy to split if you'd prefer them separate.

## Notes

- The page-layout fix is **preventive** and can't be reproduced end-to-end today: custom pages can't be created at all, because `widgetSchema` puts `z.lazy()` members inside `z.discriminatedUnion()`, which zod v3 doesn't support (the `as any` casts hide it from `tsc`), so every page write returns 400 with a `TypeError`. Confirmed on both zod 3.25.76 and 3.24.1 — a latent defect, not dependency drift. Filing separately; not fixed here to keep this PR to security changes.
- `.dev-session` uses `writeFileSync` rather than `Bun.write` because `Bun.write` silently ignores `{ mode }` for string sources. Only the BunFile-copy path honours it (oven-sh/bun#25906); string sources are still pending in oven-sh/bun#32885. This matches what `src/security/keychain.ts` already does for `credentials.key`.
